### PR TITLE
Add framework comparison article to article series

### DIFF
--- a/articles/07-agent-hive-vs-the-framework-landscape.md
+++ b/articles/07-agent-hive-vs-the-framework-landscape.md
@@ -1,0 +1,371 @@
+# Agent Hive vs. The Framework Landscape: A Different Philosophy for Agent Orchestration
+
+*This is the seventh article in a series exploring Agent Hive and AI agent orchestration.*
+
+---
+
+## The Cambrian Explosion of Agent Frameworks
+
+2024-2025 has seen an explosion of AI agent frameworks. LangGraph brings graph-based state machines. CrewAI offers role-based teams. Microsoft's AutoGen enables conversational multi-agent systems. OpenAI's Agents SDK provides lightweight handoffs. HuggingFace's smolagents takes a code-first approach.
+
+Each framework makes different tradeoffs. Each optimizes for different scenarios. And each embodies a different philosophy about what AI agents should be.
+
+Agent Hive enters this landscape not as a competitor to these frameworks, but as an alternative approach to a different problem: **long-horizon, multi-session orchestration with human oversight**.
+
+This article explores where Agent Hive fits in the framework landscape—what it shares with other approaches, where it diverges, and when you might choose one over another.
+
+## The Framework Landscape: A Quick Tour
+
+Before diving into comparisons, let's establish what each major framework offers.
+
+### LangGraph: Graph-Based State Machines
+
+[LangGraph](https://github.com/langchain-ai/langgraph), built on LangChain, represents agent workflows as directed graphs. Nodes are functions, edges define transitions, and state flows through the system.
+
+```python
+# LangGraph workflow definition
+from langgraph.graph import StateGraph
+
+workflow = StateGraph(AgentState)
+workflow.add_node("research", research_node)
+workflow.add_node("draft", draft_node)
+workflow.add_edge("research", "draft")
+```
+
+**Strengths**: Explicit state management, conditional branching, checkpointing for long-running processes, human-in-the-loop support.
+
+**Tradeoffs**: Steep learning curve, requires understanding graph theory and LangChain abstractions.
+
+### CrewAI: Role-Based Teams
+
+[CrewAI](https://www.crewai.com/) models agents as team members with defined roles, goals, and backstories. A "crew" collaborates to accomplish tasks.
+
+```python
+# CrewAI team definition
+from crewai import Agent, Task, Crew
+
+researcher = Agent(role="Research Analyst", goal="Find relevant data")
+writer = Agent(role="Content Writer", goal="Draft clear content")
+
+crew = Crew(agents=[researcher, writer], tasks=[...])
+```
+
+**Strengths**: Intuitive mental model, built-in memory types (short-term, entity, long-term), rapid prototyping.
+
+**Tradeoffs**: Sequential workflow limitations, less fine-grained control, newer ecosystem.
+
+### Microsoft AutoGen: Conversational Multi-Agent
+
+[AutoGen](https://github.com/microsoft/autogen) frames multi-agent coordination as conversations. Agents communicate in natural language to complete tasks.
+
+```python
+# AutoGen agent conversation
+assistant = AssistantAgent("assistant", llm_config=config)
+user_proxy = UserProxyAgent("user_proxy", code_execution_config={"work_dir": "coding"})
+
+user_proxy.initiate_chat(assistant, message="Write a function to sort data")
+```
+
+**Strengths**: Enterprise-grade reliability, event-driven architecture (v0.4), flexible agent dialogs, good observability.
+
+**Tradeoffs**: Conversations can loop without proper constraints, more setup required.
+
+### OpenAI Agents SDK: Lightweight Handoffs
+
+The [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) (successor to Swarm) provides minimal primitives: agents, handoffs, and guardrails.
+
+```python
+# OpenAI Agents SDK definition
+from agents import Agent
+
+triage_agent = Agent(
+    name="Triage Agent",
+    instructions="Route customer issues to the right specialist",
+    handoffs=[technical_agent, billing_agent]
+)
+```
+
+**Strengths**: Very lightweight, stateless design, built-in tracing, production-ready.
+
+**Tradeoffs**: OpenAI-specific, no persistent state between calls, requires external state management for complex workflows.
+
+### smolagents: Code-First Agents
+
+HuggingFace's [smolagents](https://github.com/huggingface/smolagents) takes a minimalist approach where agents write Python code to take actions.
+
+```python
+# smolagents code agent
+from smolagents import CodeAgent, tool
+
+agent = CodeAgent(tools=[web_search_tool], model=model)
+agent.run("Find the latest news about AI")
+```
+
+**Strengths**: Under 1000 lines of core code, 30% fewer LLM calls than JSON tool-calling, model-agnostic, sandboxed execution.
+
+**Tradeoffs**: Code execution risks, less structured coordination for multi-agent scenarios.
+
+### Anthropic MCP: The Protocol Layer
+
+Anthropic's [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) isn't a framework but a standard for connecting agents to tools and data sources—"USB-C for AI applications."
+
+**Strengths**: Open standard, thousands of community servers, vendor-agnostic connectivity.
+
+**Role**: MCP is a connectivity layer that other frameworks (including Agent Hive) can build upon.
+
+## Where Agent Hive Differs
+
+Agent Hive isn't competing with these frameworks for the same use cases. The differences are philosophical, architectural, and practical.
+
+### Philosophy: Session-Oriented vs. Continuous
+
+Most agent frameworks assume **continuous operation**—the agent runs, maintains state in memory, and executes until done. State lives in objects, databases, or runtime checkpoints.
+
+Agent Hive assumes **discrete sessions**—work happens in bounded time windows, context windows are finite, and every session starts fresh. State lives in human-readable files committed to git.
+
+This isn't a limitation we're working around. It's a design choice reflecting how agents actually work on long-horizon projects:
+
+- Context windows have hard limits
+- Sessions time out or get interrupted
+- Different agents (or humans) may continue the work
+- State needs to survive across days, not just minutes
+
+### Architecture: External Orchestration vs. Self-Direction
+
+In LangGraph, CrewAI, and AutoGen, agents largely self-direct. The framework provides structure, but agents decide what to do next based on their goals and the current state.
+
+Agent Hive adds **external orchestration** through the Cortex engine:
+
+```bash
+# Cortex analyzes all projects and updates state
+uv run python -m src.cortex
+```
+
+Cortex runs on a schedule (every 4 hours via GitHub Actions), reads all AGENCY.md files, analyzes dependencies, and updates project metadata. It never executes code—it only coordinates.
+
+This separation matters for oversight. The orchestration layer is auditable, predictable, and can catch issues that self-directed agents miss.
+
+### State: Markdown vs. In-Memory/Database
+
+Here's where Agent Hive makes its most distinctive choice.
+
+**Other frameworks**:
+- LangGraph: TypedDict state objects, SQLite checkpoints
+- CrewAI: ChromaDB vectors, SQLite tables
+- AutoGen: In-memory conversations, optional persistence
+- OpenAI SDK: Stateless (external persistence required)
+
+**Agent Hive**: Markdown files with YAML frontmatter.
+
+```markdown
+---
+project_id: auth-feature
+status: active
+owner: null
+blocked: false
+priority: high
+dependencies:
+  blocked_by: [database-schema]
+---
+
+# Authentication Feature
+
+## Tasks
+- [x] Research OAuth2 providers
+- [ ] Implement login endpoints
+
+## Agent Notes
+- **2025-01-15 14:30 - claude-sonnet-4**: Starting implementation phase.
+```
+
+Why Markdown?
+
+1. **Human-readable**: No query language needed. Open in any text editor.
+2. **Git-native**: All state changes are commits. Full history, diffs, reverts.
+3. **Vendor-agnostic**: Any LLM can read and write Markdown.
+4. **Debuggable**: When something goes wrong, you can literally read what happened.
+
+The tradeoff is query performance. LangGraph's SQLite checkpointer is faster than parsing Markdown files. CrewAI's vector store enables semantic search. For thousands of projects, you'd need caching.
+
+But for most real-world orchestration scenarios—dozens to hundreds of projects—human readability outweighs millisecond query times.
+
+### Multi-Agent Coordination: Protocols vs. Conversations
+
+AutoGen coordinates agents through natural language conversations. Agents literally talk to each other:
+
+```
+Assistant: I've analyzed the data. Here are my findings...
+Critic: Your analysis misses the edge case where...
+Assistant: You're right. Let me revise...
+```
+
+Agent Hive coordinates through **explicit protocols** and **shared state**:
+
+```markdown
+## Agent Notes
+- **2025-01-15 16:00 - grok-beta**: @claude-sonnet-4 - found an issue with
+  the token refresh logic. Implementing workaround.
+- **2025-01-15 15:30 - claude-sonnet-4**: DECISION: Using JWT instead of
+  sessions. Rationale: stateless scaling.
+```
+
+Conversations are flexible but can loop indefinitely. Protocols are rigid but predictable. For production orchestration where you need auditability, protocols win.
+
+### Vendor Lock-In: Agnostic by Design
+
+OpenAI's Agents SDK works with OpenAI models. LangGraph is optimized for LangChain's model abstractions. smolagents supports multiple providers but is HuggingFace-native.
+
+Agent Hive is **vendor-agnostic by design**:
+
+- AGENCY.md files are plain Markdown—any LLM can process them
+- Cortex uses OpenRouter, supporting Claude, GPT-4, Grok, Gemini, and more
+- The same project can be worked on by different models in sequence
+- A human with a text editor is a valid "agent"
+
+```yaml
+# Same project, different agents over time
+## Agent Notes
+- **2025-01-15 - claude-sonnet-4**: Completed research phase
+- **2025-01-16 - gpt-4-turbo**: Reviewed research, started implementation
+- **2025-01-17 - human (alice@example.com)**: Fixed edge case in auth flow
+```
+
+This matters for teams that want to use the best model for each task, or who don't want to bet their orchestration infrastructure on a single provider.
+
+## The Tradeoff Matrix
+
+| Dimension | LangGraph | CrewAI | AutoGen | OpenAI SDK | smolagents | Agent Hive |
+|-----------|-----------|--------|---------|------------|------------|------------|
+| **Learning Curve** | Steep | Easy | Moderate | Easy | Easy | Moderate |
+| **State Persistence** | Checkpoints | Database | In-memory | Stateless | In-memory | Git/Markdown |
+| **Human Readability** | Low | Low | Low | Low | Low | High |
+| **Multi-Agent** | Graph edges | Crew roles | Conversations | Handoffs | Orchestrator | Protocols |
+| **Vendor Lock-in** | LangChain | Moderate | Microsoft | OpenAI | HuggingFace | None |
+| **Long-Horizon** | Checkpointing | Limited | Limited | External | Limited | Native |
+| **Human Oversight** | Interrupt points | Limited | Limited | Guardrails | Limited | Core design |
+| **Query Performance** | High | High | Medium | N/A | Medium | Low |
+
+## When to Use What
+
+### Choose LangGraph if:
+- You need complex, branching workflows with fine-grained control
+- Performance and checkpoint recovery are critical
+- Your team knows LangChain and graph-based thinking
+- You're building real-time agent systems
+
+### Choose CrewAI if:
+- You want rapid prototyping with intuitive team metaphors
+- Built-in memory management is valuable
+- Sequential workflows fit your use case
+- You're building collaborative content generation
+
+### Choose AutoGen if:
+- Enterprise reliability and observability are priorities
+- Agent conversations naturally fit your problem
+- Microsoft ecosystem integration matters
+- You need event-driven, distributed architectures
+
+### Choose OpenAI SDK if:
+- Lightweight, minimal abstraction is preferred
+- You're already committed to OpenAI
+- Handoff patterns fit your use case
+- You'll handle persistence externally
+
+### Choose smolagents if:
+- Minimalism appeals to you (< 1000 lines of core code)
+- Code-generating agents fit your problem
+- You want model flexibility
+- HuggingFace ecosystem integration helps
+
+### Choose Agent Hive if:
+- Projects span multiple sessions over days or weeks
+- Human oversight and auditability are requirements
+- You need vendor-agnostic operation
+- Transparency (anyone can read the state) matters
+- You want git-based version control of all orchestration state
+- Multiple agents (or humans) will work on the same projects
+
+## Complementary, Not Competitive
+
+Here's the key insight: **Agent Hive can work alongside other frameworks**.
+
+Consider this architecture:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      Agent Hive                             │
+│  (Long-horizon orchestration, human oversight, git state)   │
+├─────────────────────────────────────────────────────────────┤
+│  Project A          │  Project B          │  Project C      │
+│  ┌───────────────┐  │  ┌───────────────┐  │  ┌───────────┐  │
+│  │   LangGraph   │  │  │    CrewAI     │  │  │  smolagent │  │
+│  │  (complex     │  │  │  (research    │  │  │  (code    │  │
+│  │   workflow)   │  │  │   team)       │  │  │   tasks)  │  │
+│  └───────────────┘  │  └───────────────┘  │  └───────────┘  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+Agent Hive coordinates **between** projects and **across** sessions. The individual agents within a session can use whatever framework fits their task.
+
+A LangGraph agent could:
+1. Read the AGENCY.md to understand what needs doing
+2. Execute its complex workflow
+3. Update the AGENCY.md with results
+4. Set `owner: null` to release the project
+
+The frameworks handle **intra-session execution**. Agent Hive handles **inter-session coordination**.
+
+## The Deeper Question
+
+The proliferation of agent frameworks reflects a deeper question the industry is wrestling with: **What's the right abstraction for AI agent systems?**
+
+- Is it graphs (LangGraph)?
+- Is it teams (CrewAI)?
+- Is it conversations (AutoGen)?
+- Is it handoffs (OpenAI SDK)?
+- Is it code (smolagents)?
+- Is it files (Agent Hive)?
+
+The honest answer is: we don't know yet. The field is too young for consensus.
+
+Agent Hive bets that for **long-horizon, human-supervised orchestration**, the right abstraction is:
+
+1. **Human-readable state** (Markdown, not databases)
+2. **Explicit protocols** (conventions, not conversations)
+3. **External coordination** (Cortex, not self-direction)
+4. **Git-based persistence** (commits, not checkpoints)
+5. **Vendor agnosticism** (any LLM, not one provider)
+
+These bets may be wrong. The ecosystem may converge on different patterns. But we believe the problems Agent Hive addresses—session boundaries, human oversight, long-horizon coordination—are real and underserved by existing frameworks.
+
+## Conclusion
+
+The agent framework landscape is rich and evolving. LangGraph offers power and control. CrewAI offers intuitive team models. AutoGen offers enterprise reliability. OpenAI SDK offers lightweight simplicity. smolagents offers minimalist elegance.
+
+Agent Hive offers something different: a **session-oriented orchestration layer** built on **human-readable shared memory**. It's designed for the reality that AI agents work in discrete sessions, that humans need to understand and intervene, and that complex projects outlast any single context window.
+
+These aren't competing visions—they're complementary solutions for different parts of the agent problem space. The best architecture might use several together.
+
+What matters is choosing the right tool for your problem. If you need real-time complex workflows, reach for LangGraph. If you need multi-session orchestration with human oversight, consider Agent Hive. If you need both, use both.
+
+The agent era is just beginning. There's room for many approaches.
+
+---
+
+*Agent Hive is open source at [github.com/intertwine/hive-orchestrator](https://github.com/intertwine/hive-orchestrator). We welcome contributions, questions, and healthy debate about the right abstractions for agent systems.*
+
+## Sources
+
+- [LangGraph Architecture and Design](https://medium.com/@shuv.sdr/langgraph-architecture-and-design-280c365aaf2c) - Shuvrajyoti Debroy, Medium
+- [LangGraph Multi-Agent Orchestration Guide](https://latenode.com/blog/ai-frameworks-technical-infrastructure/langgraph-multi-agent-orchestration/langgraph-multi-agent-orchestration-complete-framework-guide-architecture-analysis-2025) - Latenode
+- [CrewAI Guide: Build Multi-Agent AI Teams](https://mem0.ai/blog/crewai-guide-multi-agent-ai-teams) - Mem0
+- [CrewAI Memory Documentation](https://docs.crewai.com/en/concepts/memory) - CrewAI Docs
+- [Microsoft AutoGen Framework](https://github.com/microsoft/autogen) - Microsoft Research
+- [Microsoft's Agentic Frameworks: AutoGen and Semantic Kernel](https://devblogs.microsoft.com/autogen/microsofts-agentic-frameworks-autogen-and-semantic-kernel/) - Microsoft DevBlogs
+- [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/) - OpenAI
+- [New Tools for Building Agents](https://openai.com/index/new-tools-for-building-agents/) - OpenAI
+- [smolagents: Agents That Think in Code](https://huggingface.co/blog/smolagents) - HuggingFace
+- [Introducing the Model Context Protocol](https://www.anthropic.com/news/model-context-protocol) - Anthropic
+- [The State of AI Agent Platforms in 2025](https://www.ionio.ai/blog/the-state-of-ai-agent-platforms-in-2025-comparative-analysis) - Ionio
+- [Best AI Agent Frameworks in 2025](https://langwatch.ai/blog/best-ai-agent-frameworks-in-2025-comparing-langgraph-dspy-crewai-agno-and-more) - LangWatch
+- [Top AI Agent Frameworks Comparison](https://www.datagrom.com/data-science-machine-learning-ai-blog/langgraph-vs-autogen-vs-crewai-comparison-agentic-ai-frameworks) - Datagrom

--- a/articles/README.md
+++ b/articles/README.md
@@ -40,6 +40,12 @@ This directory contains a series of articles explaining the design philosophy, f
 
 **Key topics:** Installation, project creation, dashboard usage, dependencies, Cortex runs, common patterns, troubleshooting.
 
+### 7. [Agent Hive vs. The Framework Landscape](07-agent-hive-vs-the-framework-landscape.md)
+
+*Framework comparison.* Deep dive into how Agent Hive compares to other leading AI agent frameworks including LangGraph, CrewAI, AutoGen, OpenAI Agents SDK, and smolagents.
+
+**Key topics:** Framework philosophies, state management approaches, multi-agent coordination patterns, vendor lock-in considerations, when to use which framework, complementary architectures.
+
 ## Reading Order
 
 For newcomers, we recommend reading in order:
@@ -47,7 +53,7 @@ For newcomers, we recommend reading in order:
 1. **Article 1** - Understand the problem and solution
 2. **Article 6** - Get hands-on experience
 3. **Articles 3-5** - Deep dive into specific features
-4. **Article 2** - Context on the broader ecosystem
+4. **Articles 2 & 7** - Context on the broader ecosystem and framework comparisons
 
 ## Contributing
 


### PR DESCRIPTION
Compare Agent Hive's approach to leading agent frameworks:
- LangGraph (graph-based state machines)
- CrewAI (role-based teams)
- Microsoft AutoGen (conversational multi-agent)
- OpenAI Agents SDK (lightweight handoffs)
- smolagents (code-first agents)
- Anthropic MCP (protocol layer)

Highlights key differentiators: session-oriented design, human-readable
Markdown state, vendor-agnostic operation, external orchestration via
Cortex, and git-based persistence. Includes tradeoff matrix and guidance
on when to use each framework.