### PR TITLE
Fix dispatcher exit code when no work available

### DIFF
--- a/src/agent_dispatcher.py
+++ b/src/agent_dispatcher.py
@@ -359,7 +359,7 @@ class AgentDispatcher:
         if not ready_projects:
             print("\n No work available to dispatch")
             print("=" * 60)
-            return False
+            return True  # No work is not an error, just nothing to do
 
         # Display candidates
         print("\n Candidates:")
@@ -397,7 +397,7 @@ class AgentDispatcher:
         print(f" DISPATCH COMPLETE: {dispatched} project(s) dispatched")
         print("=" * 60)
 
-        return dispatched > 0
+        return True  # Successful completion, regardless of dispatch count
 
 
 def parse_args() -> argparse.Namespace:

--- a/tests/test_agent_dispatcher.py
+++ b/tests/test_agent_dispatcher.py
@@ -405,15 +405,15 @@ class TestRun:
         mock_dispatch.assert_called_once()
 
     @patch.object(AgentDispatcher, "validate_environment")
-    def test_returns_false_when_no_work(self, mock_validate, temp_hive_dir):
-        """Test returns False when no work available."""
+    def test_returns_true_when_no_work(self, mock_validate, temp_hive_dir):
+        """Test returns True when no work available (no work is not an error)."""
         mock_validate.return_value = True
 
         # No projects in temp_hive_dir initially
         dispatcher = AgentDispatcher(base_path=temp_hive_dir, dry_run=False)
         result = dispatcher.run()
 
-        assert result is False
+        assert result is True  # No work is success, not failure
 
     def test_dry_run_skips_validation(self, temp_hive_dir):
         """Test dry run skips environment validation."""
@@ -422,8 +422,8 @@ class TestRun:
         # Should not fail even without gh installed
         result = dispatcher.run()
 
-        # Returns False because no work, but didn't fail validation
-        assert result is False
+        # Returns True - no work is success, validation was skipped
+        assert result is True
 
     @patch.object(AgentDispatcher, "validate_environment")
     def test_respects_max_dispatches(self, mock_validate, temp_hive_dir):


### PR DESCRIPTION
The dispatcher now exits with code 0 when no work is found, since this
is not an error condition - it's a successful check that found nothing
to do. Exit code 1 is now reserved for actual errors like environment
validation failures.