### PR TITLE
Fix nested project discovery for cross-repo workflows

### DIFF
--- a/src/cortex.py
+++ b/src/cortex.py
@@ -108,7 +108,9 @@ class Cortex:
             print(f"WARNING: Projects directory not found at {self.projects_dir}")
             return projects
 
-        agency_files = glob.glob(str(self.projects_dir / "*" / "AGENCY.md"))
+        agency_files = glob.glob(
+            str(self.projects_dir / "**" / "AGENCY.md"), recursive=True
+        )
 
         for agency_file in agency_files:
             try:

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -39,7 +39,7 @@ def discover_projects(base_path: Path):
     if not projects_dir.exists():
         return []
 
-    agency_files = glob.glob(str(projects_dir / "*" / "AGENCY.md"))
+    agency_files = glob.glob(str(projects_dir / "**" / "AGENCY.md"), recursive=True)
     projects = []
 
     for agency_file in agency_files:


### PR DESCRIPTION
This pull request enhances project discovery in both the `cortex.py` and `dashboard.py` modules to support nested project directories, and adds corresponding tests to ensure correct behavior. The main change is updating the logic to recursively search for `AGENCY.md` files, allowing projects to be organized in subdirectories rather than only at the top level.

**Project discovery improvements:**

* Updated the glob pattern in `discover_projects` methods in both `src/cortex.py` and `src/dashboard.py` to recursively search for `AGENCY.md` files in all subdirectories, enabling detection of nested projects. [[1]](diffhunk://#diff-11495e7ccdc79e3d78a415f9d60ff71cdf2ac2bc8dd35fa6a2c7429f452e8004L111-R113) [[2]](diffhunk://#diff-06135492c180d831917894055e5bb06ed9c4f31998a88b446abd432d50f6a4c7L42-R42)

**Testing enhancements:**

* Added `test_discover_nested_projects` to `tests/test_cortex.py` to verify that nested projects are discovered correctly and both nested and regular projects are found.
* Added `test_discover_nested_projects` to `tests/test_dashboard.py` to ensure the dashboard's project discovery also finds projects in nested directories, with assertions for both nested and regular projects.The glob patterns in cortex.py and dashboard.py only searched one level deep (projects/*/AGENCY.md), which missed projects in nested directories like projects/external/social-compliance-generator/AGENCY.md.

Changes:
- Update glob pattern to use recursive=True with **/ for nested discovery
- Add tests for nested project discovery in both cortex and dashboard

This enables the cross-repo workflow where external projects are organized under projects/external/<project-name>/.



1. Test case 1...
2. Test case 2...

## Screenshots (if applicable)

Add screenshots to help explain your changes.

## Additional Notes

Any additional information reviewers should know.
