### PR TITLE
Add unattended YOLO loop support: heartbeat, runner scripts, dispatch profiles, and docs

### DIFF
--- a/articles/13-ralph-wiggum-and-loom-yolo-loops-edited.md
+++ b/articles/13-ralph-wiggum-and-loom-yolo-loops-edited.md
@@ -1,0 +1,113 @@
+# Ralph Wiggum and Loom YOLO Loops
+
+_A practical guide to running Agent Hive in continuous, opt-in dispatch loops across models, agents, repos, and MCP-connected integrations._
+
+## Why YOLO loops exist
+
+Agent Hive already knows how to find ready work, assemble context, and dispatch it. A YOLO loop keeps that capability running. Instead of a single dispatch run, the dispatcher cycles continuously, looking for new ready tasks and routing them to the right agent.
+
+YOLO loops are opt-in because they can run forever. They’re meant for long-running coordination when you want the hive to keep moving without a human watching every cycle.
+
+## Two styles: Ralph Wiggum vs. Loom
+
+Both styles use the same dispatcher. The difference is how they idle between cycles.
+
+### Ralph Wiggum style
+
+The Ralph Wiggum loop is aggressive. It uses a short, fixed sleep interval and does not back off when there’s no work. It keeps checking. It keeps dispatching. It’s the “I’m in danger” setting for teams that want maximum throughput and accept constant activity.
+
+### Loom style
+
+The Loom loop weaves in backoff. If the hive is idle, the sleep interval grows. When work appears, it resets to the base sleep time. This is the safer default for long-running, unattended loops.
+
+## How to enable YOLO loops (CLI)
+
+The dispatcher stays single-run by default. YOLO loops are explicit.
+
+```bash
+# Loom style (default style for YOLO mode)
+python -m src.agent_dispatcher --yolo-loop --yolo-style loom
+
+# Ralph Wiggum style (aggressive, fixed cadence)
+python -m src.agent_dispatcher --yolo-loop --yolo-style ralph-wiggum --loop-sleep 5
+
+# Cap a loop to N cycles (useful for testing)
+python -m src.agent_dispatcher --yolo-loop --loop-max-cycles 25
+```
+
+## Dispatch profiles: choose agents, models, and integrations
+
+A YOLO loop only helps if it can route to multiple agents and integrations. Agent Hive supports a lightweight dispatch profile in `AGENCY.md` metadata. Each project can declare its agent name, mention handle, and routing labels.
+
+```yaml
+---
+project_id: search-ops
+status: active
+priority: high
+owner: null
+
+dispatch:
+  agent_name: gpt-5-search
+  mention: "@opencode"
+  labels:
+    - model:gpt-5
+    - integration:mcp
+    - skill:web-search
+---
+```
+
+**What this does:**
+- **agent_name** becomes the project owner on claim.
+- **mention** is used in the issue body and follow-up comment to notify the right agent.
+- **labels** help external automations or skills know which integrations to attach.
+
+That lets a single hive route work:
+- **Across models**: Claude, GPT-5, Gemini, or local models.
+- **Across agents**: Claude Code, OpenCode agents, or custom runners.
+- **Across repos**: local hive projects or `target_repo` workflows.
+- **Across integrations**: MCP servers and skills that subscribe to labels.
+
+## Multi-agent routing in practice
+
+You can still force a default agent on the CLI when you want a single loop runner to handle everything:
+
+```bash
+python -m src.agent_dispatcher \
+  --yolo-loop \
+  --agent-name claude-sonnet-4 \
+  --agent-mention @claude \
+  --extra-label model:claude-sonnet-4
+```
+
+The real power shows up when different projects declare different dispatch profiles. One loop can rotate across all of them without manual handoffs.
+
+## Safety notes for infinite loops
+
+YOLO loops are powerful. They’re also easy to let run forever. Best practices:
+
+- Start with Loom style when running unattended.
+- Set `loop-max-cycles` for early testing.
+- Use labels to drive skills and MCP routing instead of hard-coding behavior.
+- Monitor GitHub issue throughput or add tracing when you need auditability.
+
+## Running unattended without GitHub Actions
+
+If you want YOLO loops outside GitHub Actions, run them from a local machine, a VM, or a cloud sandbox. The dispatcher can write a heartbeat JSON file every cycle with `--loop-heartbeat`, which makes monitoring straightforward.
+
+The repo includes helper scripts for background runs:
+
+```bash
+export HIVE_BASE_PATH=/path/to/hive-orchestrator
+export YOLO_STYLE=loom
+export SLEEP_SECONDS=30
+export AGENT_NAME=claude-sonnet-4
+export AGENT_MENTION=@claude
+
+scripts/run_yolo_loop.sh
+```
+
+For systemd, container, and VM examples, see `docs/yolo-loop-unattended.md`.
+
+## Summary
+
+Ralph Wiggum loops give you speed. Loom loops give you stability. Both are opt-in, both work across models and agents, and both keep the hive moving without manual babysitting.

--- a/articles/13-ralph-wiggum-and-loom-yolo-loops.md
+++ b/articles/13-ralph-wiggum-and-loom-yolo-loops.md
@@ -1,0 +1,113 @@
+# Ralph Wiggum and Loom YOLO Loops
+
+_A practical guide to running Agent Hive in continuous, opt-in dispatch loops across models, agents, repos, and MCP-connected integrations._
+
+## Why YOLO loops exist
+
+Agent Hive already knows how to find ready work, assemble context, and dispatch it. A YOLO loop makes that capability continuous. Instead of a single dispatch run, the dispatcher keeps cycling, looking for new ready tasks and routing them to whichever agent is configured for that project.
+
+These loops are **opt-in** because they can run forever. They’re designed for long-running, largely unmonitored coordination when you want the hive to keep moving.
+
+## Two styles: Ralph Wiggum vs. Loom
+
+Both styles use the same dispatcher. The difference is in how they idle between cycles.
+
+### Ralph Wiggum style
+
+The Ralph Wiggum loop is intentionally aggressive. It runs on a short, fixed sleep interval and does not back off when there’s no work. It keeps checking. It keeps dispatching. It’s the “I’m in danger” setting for teams that want maximum throughput and accept the risk of constant activity.
+
+### Loom style
+
+The Loom loop is a weaving pattern. It does the same work, but it backs off when the hive is idle. No work found? It sleeps longer. Work found? It resets to the base sleep interval. This makes it more stable for long-running, unattended loops.
+
+## How to enable YOLO loops (CLI)
+
+The dispatcher stays single-run by default. YOLO loops are explicit.
+
+```bash
+# Loom style (default style for YOLO mode)
+python -m src.agent_dispatcher --yolo-loop --yolo-style loom
+
+# Ralph Wiggum style (aggressive, fixed cadence)
+python -m src.agent_dispatcher --yolo-loop --yolo-style ralph-wiggum --loop-sleep 5
+
+# Cap a loop to N cycles (useful for testing)
+python -m src.agent_dispatcher --yolo-loop --loop-max-cycles 25
+```
+
+## Dispatch profiles: choose agents, models, and integrations
+
+A YOLO loop is only useful if it can route to multiple agents and integrations. Agent Hive now supports a lightweight dispatch profile in your `AGENCY.md` metadata. This lets each project opt into a specific agent name, mention handle, and routing labels.
+
+```yaml
+---
+project_id: search-ops
+status: active
+priority: high
+owner: null
+
+dispatch:
+  agent_name: gpt-5-search
+  mention: "@opencode"
+  labels:
+    - model:gpt-5
+    - integration:mcp
+    - skill:web-search
+---
+```
+
+**What this does:**
+- **agent_name** becomes the project owner on claim.
+- **mention** is used in the issue body and follow-up comment to notify the right agent.
+- **labels** help external automations or skills know which integrations to attach.
+
+That means a single hive can route:
+- **Across models**: claude, gpt-5, gemini, or local models.
+- **Across agents**: Claude Code, OpenCode agents, or custom runners.
+- **Across repos**: local hive projects or `target_repo` workflows.
+- **Across integrations**: MCP servers and skills that subscribe to labels.
+
+## Multi-agent routing in practice
+
+You can still force a default agent on the CLI when you want a single loop runner to handle everything:
+
+```bash
+python -m src.agent_dispatcher \
+  --yolo-loop \
+  --agent-name claude-sonnet-4 \
+  --agent-mention @claude \
+  --extra-label model:claude-sonnet-4
+```
+
+But the real power shows up when different projects declare different dispatch profiles. A single loop can rotate across all of them without manual handoffs.
+
+## Safety notes for infinite loops
+
+YOLO loops are powerful. They’re also easy to let run forever. Best practices:
+
+- Start with Loom style when running unattended.
+- Set `loop-max-cycles` for early testing.
+- Use labels to drive skills and MCP routing instead of hard-coding behavior.
+- Monitor GitHub issue throughput or add tracing if you need auditability.
+
+## Running unattended without GitHub Actions
+
+If you want YOLO loops outside GitHub Actions, run them from a local machine, a VM, or a cloud sandbox. The dispatcher writes a heartbeat JSON file every cycle when you pass `--loop-heartbeat`, which makes it easy to add monitoring or watchdogs.
+
+The repository includes helper scripts for background runs:
+
+```bash
+export HIVE_BASE_PATH=/path/to/hive-orchestrator
+export YOLO_STYLE=loom
+export SLEEP_SECONDS=30
+export AGENT_NAME=claude-sonnet-4
+export AGENT_MENTION=@claude
+
+scripts/run_yolo_loop.sh
+```
+
+For systemd, container, and VM examples, see `docs/yolo-loop-unattended.md`.
+
+## Summary
+
+Ralph Wiggum loops give you speed. Loom loops give you stability. Both are opt-in, both work across models and agents, and both keep the hive moving without manual babysitting.

--- a/articles/README.md
+++ b/articles/README.md
@@ -70,6 +70,18 @@ This directory contains a series of articles explaining the design philosophy, f
 
 **Key topics:** target_repo metadata, context assembly, multi-phase improvements, external repository analysis, cross-repo PR workflows, security considerations.
 
+### 12. [OpenCode Integration](12-opencode-integration.md)
+
+*Model-agnostic execution.* How to integrate Agent Hive with OpenCode to run workflows across providers while preserving Agent Hive’s coordination model.
+
+**Key topics:** OpenCode setup, MCP tools, skills parity, multi-model support, integration architecture, decision paths.
+
+### 13. [Ralph Wiggum and Loom YOLO Loops](13-ralph-wiggum-and-loom-yolo-loops.md)
+
+*Continuous dispatching.* How to run opt-in YOLO loops for long-running, multi-agent work across models and integrations.
+
+**Key topics:** YOLO loop styles, dispatch profiles, routing across agents, safe long-running loop practices.
+
 ## Reading Order
 
 For newcomers, we recommend reading in order:
@@ -82,6 +94,8 @@ For newcomers, we recommend reading in order:
 6. **Article 9** - Security best practices (important for production)
 7. **Article 10** - Observability and monitoring
 8. **Article 11** - Cross-repository workflows for external projects
+9. **Article 12** - OpenCode integration for model-agnostic execution
+10. **Article 13** - YOLO loops for continuous dispatching
 
 ## Contributing
 

--- a/docs/yolo-loop-unattended.md
+++ b/docs/yolo-loop-unattended.md
@@ -1,0 +1,96 @@
+# Running YOLO Loops Unattended (Local or Cloud)
+
+This guide shows how to run Agent Hive YOLO loops without GitHub Actions. It targets three scenarios:
+
+1. **Local workstation** (background process with logs + heartbeat)
+2. **Cloud sandbox** (long-lived VM or container)
+3. **Systemd service** (production-ish supervision)
+
+## 1) Local machine (background process)
+
+Use the helper scripts in `scripts/` for a simple supervised run. These scripts write:
+
+- **PID file**: used for stop/restart
+- **Log file**: append-only log output
+- **Heartbeat JSON**: updated after every loop cycle
+
+```bash
+export HIVE_BASE_PATH=/path/to/hive-orchestrator
+export YOLO_STYLE=loom
+export SLEEP_SECONDS=30
+export MAX_DISPATCHES=1
+export AGENT_NAME=claude-sonnet-4
+export AGENT_MENTION=@claude
+export EXTRA_LABELS="model:claude-sonnet-4,integration:mcp"
+
+scripts/run_yolo_loop.sh
+```
+
+To stop:
+
+```bash
+export HIVE_BASE_PATH=/path/to/hive-orchestrator
+scripts/stop_yolo_loop.sh
+```
+
+## 2) Cloud sandbox (VM/container)
+
+Any long-lived VM or container can run the loop. The two things you need are:
+
+- An OpenRouter API key (for Cortex)
+- GitHub CLI auth if you want issue creation
+
+Example (container entrypoint):
+
+```bash
+uv run python -m src.agent_dispatcher \
+  --path /app \
+  --yolo-loop \
+  --yolo-style loom \
+  --loop-sleep 30 \
+  --loop-heartbeat /app/yolo-loop-heartbeat.json
+```
+
+You can pair that with your platform’s health checks by watching the heartbeat file.
+
+## 3) Systemd service (Linux)
+
+Below is a minimal unit file. Adjust paths for your environment.
+
+```ini
+# /etc/systemd/system/agent-hive-yolo.service
+[Unit]
+Description=Agent Hive YOLO Loop
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/hive-orchestrator
+Environment=OPENROUTER_API_KEY=...your key...
+ExecStart=/usr/bin/env bash -lc \
+  "uv run python -m src.agent_dispatcher \
+    --path /opt/hive-orchestrator \
+    --yolo-loop \
+    --yolo-style loom \
+    --loop-sleep 30 \
+    --loop-heartbeat /opt/hive-orchestrator/yolo-loop-heartbeat.json"
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable and start:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable agent-hive-yolo
+sudo systemctl start agent-hive-yolo
+```
+
+## Operational notes
+
+- **Heartbeat JSON** is updated after each loop cycle. Use it for watchdogs.
+- **Logs** are your primary audit trail. Pipe them to your log stack if needed.
+- **Backoff** is handled by the `loom` style; use `ralph-wiggum` only when you want aggressive polling.

--- a/scripts/run_yolo_loop.sh
+++ b/scripts/run_yolo_loop.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HIVE_BASE_PATH=${HIVE_BASE_PATH:-"$(pwd)"}
+LOG_PATH=${LOG_PATH:-"$HIVE_BASE_PATH/yolo-loop.log"}
+PID_PATH=${PID_PATH:-"$HIVE_BASE_PATH/yolo-loop.pid"}
+HEARTBEAT_PATH=${HEARTBEAT_PATH:-"$HIVE_BASE_PATH/yolo-loop-heartbeat.json"}
+YOLO_STYLE=${YOLO_STYLE:-"loom"}
+SLEEP_SECONDS=${SLEEP_SECONDS:-"30"}
+MAX_DISPATCHES=${MAX_DISPATCHES:-"1"}
+AGENT_NAME=${AGENT_NAME:-"claude-code"}
+AGENT_MENTION=${AGENT_MENTION:-"@claude"}
+EXTRA_LABELS=${EXTRA_LABELS:-""}
+
+if [[ -f "$PID_PATH" ]]; then
+  echo "PID file exists at $PID_PATH. Stop the existing loop before starting a new one."
+  exit 1
+fi
+
+cmd=(
+  uv run python -m src.agent_dispatcher
+  --path "$HIVE_BASE_PATH"
+  --yolo-loop
+  --yolo-style "$YOLO_STYLE"
+  --loop-sleep "$SLEEP_SECONDS"
+  --loop-heartbeat "$HEARTBEAT_PATH"
+  --max "$MAX_DISPATCHES"
+  --agent-name "$AGENT_NAME"
+)
+
+if [[ -n "$AGENT_MENTION" ]]; then
+  cmd+=(--agent-mention "$AGENT_MENTION")
+else
+  cmd+=(--agent-mention none)
+fi
+
+IFS=',' read -r -a labels <<< "$EXTRA_LABELS"
+for label in "${labels[@]}"; do
+  trimmed=$(echo "$label" | xargs)
+  if [[ -n "$trimmed" ]]; then
+    cmd+=(--extra-label "$trimmed")
+  fi
+done
+
+echo "Starting YOLO loop..."
+nohup "${cmd[@]}" >> "$LOG_PATH" 2>&1 &
+loop_pid=$!
+
+echo "$loop_pid" > "$PID_PATH"
+echo "Started. PID: $loop_pid"
+echo "Logs: $LOG_PATH"
+echo "Heartbeat: $HEARTBEAT_PATH"

--- a/scripts/stop_yolo_loop.sh
+++ b/scripts/stop_yolo_loop.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HIVE_BASE_PATH=${HIVE_BASE_PATH:-"$(pwd)"}
+PID_PATH=${PID_PATH:-"$HIVE_BASE_PATH/yolo-loop.pid"}
+
+if [[ ! -f "$PID_PATH" ]]; then
+  echo "No PID file found at $PID_PATH"
+  exit 0
+fi
+
+loop_pid=$(cat "$PID_PATH")
+if [[ -z "$loop_pid" ]]; then
+  echo "PID file is empty."
+  exit 1
+fi
+
+if kill "$loop_pid" >/dev/null 2>&1; then
+  echo "Stopped YOLO loop process $loop_pid"
+else
+  echo "Failed to stop process $loop_pid (may not be running)"
+fi
+
+rm -f "$PID_PATH"

--- a/src/agent_dispatcher.py
+++ b/src/agent_dispatcher.py
@@ -3,15 +3,18 @@
 Agent Hive Agent Dispatcher
 
 Finds ready work, assembles context, creates GitHub issues, and assigns
-work to Claude Code for autonomous execution.
+work to configured agents for autonomous execution.
 """
 
 import argparse
 import os
 import subprocess
 import sys
+import time
+import json
 from pathlib import Path
 from datetime import datetime, timezone
+from dataclasses import dataclass
 from typing import Dict, Any, List, Optional
 from dotenv import load_dotenv
 
@@ -37,6 +40,18 @@ class DispatcherError(Exception):
     """Base exception for Dispatcher-related errors."""
 
 
+DEFAULT_AGENT_NAME = "claude-code"
+DEFAULT_AGENT_MENTION = "@claude"
+
+
+@dataclass
+class DispatchProfile:
+    agent_name: str
+    mention: Optional[str]
+    comment: Optional[str]
+    labels: List[str]
+
+
 class AgentDispatcher:
     """
     The Agent Dispatcher for Agent Hive.
@@ -45,14 +60,18 @@ class AgentDispatcher:
     - Find ready work using Cortex
     - Select highest priority project
     - Build rich context for agent assignment
-    - Create GitHub issue with @claude mention
+    - Create GitHub issue with agent mention
     - Update AGENCY.md to claim ownership
     """
 
-    # Agent name used when claiming projects
-    AGENT_NAME = "claude-code"
-
-    def __init__(self, base_path: str = None, dry_run: bool = False):
+    def __init__(
+        self,
+        base_path: str = None,
+        dry_run: bool = False,
+        agent_name: str = DEFAULT_AGENT_NAME,
+        agent_mention: Optional[str] = DEFAULT_AGENT_MENTION,
+        extra_labels: Optional[List[str]] = None,
+    ):
         """
         Initialize the Agent Dispatcher.
 
@@ -62,6 +81,9 @@ class AgentDispatcher:
         """
         self.base_path = Path(base_path or os.getcwd())
         self.dry_run = dry_run
+        self.agent_name = agent_name
+        self.agent_mention = agent_mention
+        self.extra_labels = extra_labels or []
         self.cortex = Cortex(str(self.base_path))
 
     def validate_environment(self) -> bool:
@@ -174,7 +196,7 @@ class AgentDispatcher:
         owner = project.get("metadata", {}).get("owner")
         return owner is not None
 
-    def claim_project(self, project: Dict[str, Any], issue_url: str) -> bool:
+    def claim_project(self, project: Dict[str, Any], issue_url: str, agent_name: str) -> bool:
         """
         Claim a project by setting owner and adding issue link to AGENCY.md.
 
@@ -198,14 +220,14 @@ class AgentDispatcher:
             parsed = safe_load_agency_md(project_path)
 
             # Update metadata
-            parsed.metadata["owner"] = self.AGENT_NAME
+            parsed.metadata["owner"] = agent_name
             parsed.metadata["last_updated"] = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
             # Add agent note with issue link
             timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M")
             note = (
                 f"\n- **{timestamp} - Agent Dispatcher**: "
-                f"Assigned to Claude Code. Issue: {issue_url}"
+                f"Assigned to {agent_name}. Issue: {issue_url}"
             )
 
             # Find or create Agent Notes section
@@ -300,12 +322,12 @@ class AgentDispatcher:
             print(f"   ERROR creating issue: {e}")
             return None
 
-    def add_claude_comment(self, issue_url: str) -> bool:
+    def add_agent_comment(self, issue_url: str, comment: Optional[str]) -> bool:
         """
-        Add a comment to the issue to trigger Claude Code.
+        Add a comment to the issue to trigger the configured agent.
 
         GitHub API-created issues don't trigger notifications from @mentions
-        in the initial body. A separate comment is needed to invoke Claude.
+        in the initial body. A separate comment is needed to invoke the agent.
 
         Args:
             issue_url: URL of the GitHub issue
@@ -313,16 +335,17 @@ class AgentDispatcher:
         Returns:
             True on success, False on failure
         """
+        if not comment:
+            return True
+
         if self.dry_run:
-            print("   [DRY RUN] Would add @claude comment to trigger assignment")
+            print("   [DRY RUN] Would add agent comment to trigger assignment")
             return True
 
         try:
             # Extract issue number from URL
             # URL format: https://github.com/owner/repo/issues/123
             issue_number = issue_url.rstrip("/").split("/")[-1]
-
-            comment = "@claude Please work on this issue."
 
             cmd = ["gh", "issue", "comment", issue_number, "--body", comment]
 
@@ -335,7 +358,7 @@ class AgentDispatcher:
             )
 
             if result.returncode != 0:
-                print(f"   Warning: Failed to add Claude comment: {result.stderr}")
+                print(f"   Warning: Failed to add agent comment: {result.stderr}")
                 return False
 
             return True
@@ -344,12 +367,52 @@ class AgentDispatcher:
             print("   Warning: gh comment command timed out")
             return False
         except Exception as e:
-            print(f"   Warning: Failed to add Claude comment: {e}")
+            print(f"   Warning: Failed to add agent comment: {e}")
             return False
+
+    def resolve_dispatch_profile(self, project: Dict[str, Any]) -> DispatchProfile:
+        metadata = project.get("metadata", {})
+        dispatch = metadata.get("dispatch", {}) if isinstance(metadata.get("dispatch"), dict) else {}
+
+        agent_name = dispatch.get("agent_name") or self.agent_name
+
+        if "mention" in dispatch:
+            mention = dispatch.get("mention")
+        else:
+            mention = self.agent_mention
+
+        if mention:
+            mention = mention.strip()
+            if mention and not mention.startswith("@"):
+                mention = f"@{mention}"
+        else:
+            mention = None
+
+        comment = dispatch.get("comment")
+        if comment:
+            comment = comment.strip()
+        elif mention:
+            comment = f"{mention} Please work on this issue."
+        else:
+            comment = None
+
+        labels = list(self.extra_labels)
+        dispatch_labels = dispatch.get("labels", [])
+        if isinstance(dispatch_labels, list):
+            labels.extend([str(label) for label in dispatch_labels])
+        elif isinstance(dispatch_labels, str):
+            labels.append(dispatch_labels)
+
+        return DispatchProfile(
+            agent_name=agent_name,
+            mention=mention,
+            comment=comment,
+            labels=labels,
+        )
 
     def dispatch(self, project: Dict[str, Any]) -> bool:
         """
-        Dispatch a single project to Claude Code.
+        Dispatch a single project to the configured agent.
 
         Args:
             project: Project to dispatch
@@ -366,13 +429,21 @@ class AgentDispatcher:
             print(f"   Skipping: already assigned to {project['metadata'].get('owner')}")
             return False
 
+        dispatch_profile = self.resolve_dispatch_profile(project)
+
         # Get the next task
         next_task = get_next_task(project.get("content", ""))
 
         # Build issue content
         title = build_issue_title(project_id, next_task)
-        body = build_issue_body(project, self.base_path, next_task)
-        labels = build_issue_labels(project)
+        body = build_issue_body(
+            project,
+            self.base_path,
+            next_task,
+            agent_name=dispatch_profile.agent_name,
+            agent_mention=dispatch_profile.mention,
+        )
+        labels = build_issue_labels(project, extra_labels=dispatch_profile.labels)
 
         print(f"   Title: {title}")
         print(f"   Next task: {next_task or 'none identified'}")
@@ -387,22 +458,23 @@ class AgentDispatcher:
 
         print(f"   Issue created: {issue_url}")
 
-        # Add a comment to trigger Claude Code
+        # Add a comment to trigger agent assignment
         # GitHub doesn't trigger notifications from @mentions in the initial body
-        print("   Adding @claude comment to trigger assignment...")
-        if not self.add_claude_comment(issue_url):
-            print("   Warning: Could not add Claude comment, but issue was created")
+        if dispatch_profile.comment:
+            print("   Adding agent comment to trigger assignment...")
+            if not self.add_agent_comment(issue_url, dispatch_profile.comment):
+                print("   Warning: Could not add agent comment, but issue was created")
 
         # Claim the project
         print("   Claiming project...")
-        if not self.claim_project(project, issue_url):
+        if not self.claim_project(project, issue_url, dispatch_profile.agent_name):
             print("   Failed to claim project (issue was created)")
             return False
 
         print(f"   Successfully dispatched {project_id}")
         return True
 
-    def run(self, max_dispatches: int = 1) -> bool:
+    def run_cycle(self, max_dispatches: int = 1) -> int:
         """
         Main dispatcher execution.
 
@@ -436,7 +508,7 @@ class AgentDispatcher:
         if not ready_projects:
             print("\n No work available to dispatch")
             print("=" * 60)
-            return True  # No work is not an error, just nothing to do
+            return 0  # No work is not an error, just nothing to do
 
         # Display candidates
         print("\n Candidates:")
@@ -475,13 +547,78 @@ class AgentDispatcher:
         print(f" DISPATCH COMPLETE: {dispatched} project(s) dispatched")
         print("=" * 60)
 
-        return True  # Successful completion, regardless of dispatch count
+        return dispatched
+
+    def run(self, max_dispatches: int = 1) -> bool:
+        """Run a single dispatcher cycle."""
+        self.run_cycle(max_dispatches=max_dispatches)
+        return True
+
+    def run_loop(
+        self,
+        max_dispatches: int = 1,
+        style: str = "loom",
+        sleep_seconds: int = 30,
+        max_sleep_seconds: int = 300,
+        max_cycles: Optional[int] = None,
+        heartbeat_path: Optional[Path] = None,
+    ) -> bool:
+        """Run dispatcher in a continuous YOLO loop."""
+        print("=" * 60)
+        print(" AGENT HIVE YOLO LOOP")
+        print("=" * 60)
+        print(f"Loop style: {style}")
+        print(f"Base sleep: {sleep_seconds}s")
+        if style == "loom":
+            print(f"Max sleep: {max_sleep_seconds}s")
+        if max_cycles:
+            print(f"Max cycles: {max_cycles}")
+        print()
+
+        cycle = 0
+        current_sleep = sleep_seconds
+
+        while True:
+            cycle += 1
+            print(f"\n--- YOLO cycle {cycle} ---")
+            dispatched = self.run_cycle(max_dispatches=max_dispatches)
+
+            if heartbeat_path:
+                heartbeat_payload = {
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "cycle": cycle,
+                    "dispatched": dispatched,
+                    "style": style,
+                    "sleep_seconds": sleep_seconds,
+                }
+                try:
+                    heartbeat_path.parent.mkdir(parents=True, exist_ok=True)
+                    heartbeat_path.write_text(json.dumps(heartbeat_payload), encoding="utf-8")
+                except OSError as exc:
+                    print(f"Warning: Failed to write heartbeat file: {exc}")
+
+            if max_cycles and cycle >= max_cycles:
+                print("Reached max cycles. Exiting loop.")
+                break
+
+            if style == "loom":
+                if dispatched == 0:
+                    current_sleep = min(current_sleep * 2, max_sleep_seconds)
+                else:
+                    current_sleep = sleep_seconds
+            else:
+                current_sleep = sleep_seconds
+
+            print(f"\nSleeping {current_sleep}s before next cycle...")
+            time.sleep(current_sleep)
+
+        return True
 
 
 def parse_args() -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(
-        description="Agent Hive Dispatcher - Assign work to Claude Code",
+        description="Agent Hive Dispatcher - Assign work to configured agents",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
@@ -496,6 +633,12 @@ Examples:
 
   # Specify custom base path
   python -m src.agent_dispatcher --path /path/to/hive
+
+  # Run a continuous YOLO loop (loom style)
+  python -m src.agent_dispatcher --yolo-loop --yolo-style loom
+
+  # Run an aggressive YOLO loop (ralph wiggum style)
+  python -m src.agent_dispatcher --yolo-loop --yolo-style ralph-wiggum --loop-sleep 5
         """,
     )
 
@@ -522,6 +665,68 @@ Examples:
         help="Base path for the hive (default: current directory)",
     )
 
+    parser.add_argument(
+        "--agent-name",
+        type=str,
+        default=DEFAULT_AGENT_NAME,
+        help="Agent name to claim projects with (default: claude-code)",
+    )
+
+    parser.add_argument(
+        "--agent-mention",
+        type=str,
+        default=DEFAULT_AGENT_MENTION,
+        help="GitHub mention to trigger agent notifications (default: @claude). Use 'none' to disable.",
+    )
+
+    parser.add_argument(
+        "--extra-label",
+        action="append",
+        default=[],
+        help="Extra label to add to dispatched issues (repeatable)",
+    )
+
+    parser.add_argument(
+        "--yolo-loop",
+        action="store_true",
+        help="Run the dispatcher continuously in a YOLO loop (opt-in)",
+    )
+
+    parser.add_argument(
+        "--yolo-style",
+        choices=["loom", "ralph-wiggum"],
+        default="loom",
+        help="YOLO loop style: loom (backoff) or ralph-wiggum (aggressive)",
+    )
+
+    parser.add_argument(
+        "--loop-sleep",
+        type=int,
+        default=None,
+        help="Base sleep time between YOLO cycles in seconds",
+    )
+
+    parser.add_argument(
+        "--loop-max-sleep",
+        type=int,
+        default=300,
+        help="Maximum sleep time for loom backoff in seconds",
+    )
+
+    parser.add_argument(
+        "--loop-max-cycles",
+        type=int,
+        default=None,
+        help="Maximum number of YOLO cycles before exiting (default: infinite)",
+    )
+
+    parser.add_argument(
+        "--loop-heartbeat",
+        type=str,
+        default=None,
+        help="Optional path to write a heartbeat JSON file after each loop cycle",
+    )
+
     return parser.parse_args()
 
 
@@ -536,8 +741,38 @@ def main():
         print(f"ERROR: {e}")
         sys.exit(1)
 
-    dispatcher = AgentDispatcher(base_path=args.path, dry_run=args.dry_run)
-    success = dispatcher.run(max_dispatches=max_dispatches)
+    agent_mention = args.agent_mention
+    if agent_mention and agent_mention.strip().lower() in {"none", "null", "off"}:
+        agent_mention = None
+
+    loop_sleep = args.loop_sleep
+    if loop_sleep is None:
+        loop_sleep = 5 if args.yolo_style == "ralph-wiggum" else 30
+
+    if args.loop_max_cycles is not None and args.loop_max_cycles < 1:
+        print("ERROR: loop-max-cycles must be >= 1")
+        sys.exit(1)
+
+    dispatcher = AgentDispatcher(
+        base_path=args.path,
+        dry_run=args.dry_run,
+        agent_name=args.agent_name,
+        agent_mention=agent_mention,
+        extra_labels=args.extra_label,
+    )
+
+    if args.yolo_loop:
+        heartbeat_path = Path(args.loop_heartbeat) if args.loop_heartbeat else None
+        success = dispatcher.run_loop(
+            max_dispatches=max_dispatches,
+            style=args.yolo_style,
+            sleep_seconds=loop_sleep,
+            max_sleep_seconds=args.loop_max_sleep,
+            max_cycles=args.loop_max_cycles,
+            heartbeat_path=heartbeat_path,
+        )
+    else:
+        success = dispatcher.run(max_dispatches=max_dispatches)
 
     sys.exit(0 if success else 1)
 

--- a/src/context_assembler.py
+++ b/src/context_assembler.py
@@ -276,6 +276,8 @@ def build_issue_body(
     project: Dict[str, Any],
     base_path: Path,
     next_task: Optional[str] = None,
+    agent_name: Optional[str] = None,
+    agent_mention: Optional[str] = "@claude",
 ) -> str:
     """
     Build a comprehensive GitHub issue body for agent assignment.
@@ -416,14 +418,22 @@ Focus on completing this task first:
 - [ ] AGENCY.md updated with progress
 - [ ] PR created and linked to this issue"""
 
+    mention_line = (
+        f"{agent_mention} Please work on this Agent Hive project."
+        if agent_mention
+        else "Please work on this Agent Hive project."
+    )
+    agent_label = agent_name or "unassigned"
+
     # Build the issue body
-    body = f"""@claude Please work on this Agent Hive project.
+    body = f"""{mention_line}
 
 ## Task Assignment
 
 | Field | Value |
 |-------|-------|
 | **Project** | `{project_id}` |
+| **Agent** | {agent_label} |
 | **Priority** | {priority} |
 | **Tags** | {', '.join(tags) if tags else 'none'} |
 | **Path** | `{project_path.relative_to(base_path)}` |
@@ -464,7 +474,9 @@ When you complete your work:
     return body
 
 
-def build_issue_labels(project: Dict[str, Any]) -> List[str]:
+def build_issue_labels(
+    project: Dict[str, Any], extra_labels: Optional[List[str]] = None
+) -> List[str]:
     """
     Build labels for the GitHub issue.
 
@@ -485,4 +497,7 @@ def build_issue_labels(project: Dict[str, Any]) -> List[str]:
     project_id = metadata.get("project_id", "unknown")
     labels.append(f"project:{project_id}")
 
-    return labels
+    if extra_labels:
+        labels.extend(extra_labels)
+
+    return list(dict.fromkeys(labels))


### PR DESCRIPTION
### Motivation
- Enable running the YOLO continuous dispatcher outside GitHub Actions (local machine, VM/container, or systemd) with safe monitoring and minimal ops friction. 
- Provide per-project dispatch metadata and inject agent metadata into dispatched issues so a single loop can route work across models/agents/integrations.
- Give operators a simple health signal (heartbeat) and start/stop helpers so unattended loops can be supervised by basic tooling or platform health checks.

### Description
- Added heartbeat emission to the YOLO loop in `AgentDispatcher.run_loop` and exposed it via a new CLI flag `--loop-heartbeat`, writing a JSON file each cycle with `timestamp`, `cycle`, `dispatched`, `style`, and `sleep_seconds`.
- Implemented dispatch profile resolution with a `DispatchProfile` dataclass and `resolve_dispatch_profile` to merge project `dispatch` metadata with CLI defaults, and used the profile to inject `agent_name`, `agent_mention`, `comment`, and `labels` into dispatch logic.
- Broadened dispatch plumbing: replaced `add_claude_comment` with `add_agent_comment`, updated `claim_project` to accept `agent_name`, split `run` into `run_cycle` (returns dispatched count) and `run` wrapper, and implemented `loom` backoff / `ralph-wiggum` fixed cadence in `run_loop`.
- Extended context assembly and labeling: `build_issue_body` now accepts `agent_name` and `agent_mention`, and `build_issue_labels` accepts `extra_labels` and de-duplicates labels.
- Added unattended runner scripts `scripts/run_yolo_loop.sh` and `scripts/stop_yolo_loop.sh` plus a how-to doc `docs/yolo-loop-unattended.md`, updated the YOLO article files under `articles/` and `articles/README.md`, and added/updated unit tests in `tests/test_agent_dispatcher.py` and `tests/test_context_assembler.py` (including a heartbeat emission test).

### Testing
- Ran `make test` which invoked `pytest`, but it failed early with `ModuleNotFoundError: No module named 'frontmatter'` because test/dev dependencies are not installed in this environment.
- Ran `make lint` which failed because `pylint` is not available in the environment.
- Added and updated unit tests covering dispatch profile resolution, agent metadata injection into issue bodies, extra-label handling/deduplication, claim behavior for custom owners, and `run_loop` heartbeat emission; these tests are present under `tests/` and are expected to pass once dev dependencies are installed (`make install-dev` / `uv sync --extra dev`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696aeceaf5888324a588be578d4e3423)