### PR TITLE
Add Codex app-server live bridge

### DIFF
--- a/src/hive/drivers/codex.py
+++ b/src/hive/drivers/codex.py
@@ -3,15 +3,24 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import json
 import os
 from pathlib import Path
 import shlex
 import signal
 import subprocess
+import sys
 from typing import Any
 
 from src.hive.drivers.base import HarnessDriver
-from src.hive.drivers.types import DriverInfo, RunHandle, RunLaunchRequest, RunProgress, RunStatus
+from src.hive.drivers.types import (
+    DriverInfo,
+    RunBudgetUsage,
+    RunHandle,
+    RunLaunchRequest,
+    RunProgress,
+    RunStatus,
+)
 from src.hive.runtime.capabilities import capability_surface
 from src.hive.clock import utc_now_iso
 
@@ -39,6 +48,12 @@ class CodexDriver(HarnessDriver):
             return False
         return raw.strip().lower() in {"1", "true", "yes", "on"}
 
+    def _live_app_server_enabled(self) -> bool:
+        raw = os.environ.get("HIVE_CODEX_LIVE_APP_SERVER")
+        if raw is None:
+            return False
+        return raw.strip().lower() in {"1", "true", "yes", "on"}
+
     @staticmethod
     def _pid_is_running(pid: int) -> bool:
         try:
@@ -60,6 +75,19 @@ class CodexDriver(HarnessDriver):
             return None
 
     @staticmethod
+    def _load_state(path_value: str | None) -> dict[str, Any]:
+        if not path_value:
+            return {}
+        path = Path(path_value)
+        if not path.exists():
+            return {}
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return {}
+        return payload if isinstance(payload, dict) else {}
+
+    @staticmethod
     def _event_cursor(path_value: str | None) -> str | None:
         if not path_value:
             return None
@@ -78,6 +106,20 @@ class CodexDriver(HarnessDriver):
         latest = max(candidate.stat().st_mtime for candidate in candidates)
         return datetime.fromtimestamp(latest, tz=timezone.utc).isoformat().replace("+00:00", "Z")
 
+    @staticmethod
+    def _budget_usage_from_state(state: dict[str, Any]) -> RunBudgetUsage:
+        token_usage = state.get("token_usage")
+        if not isinstance(token_usage, dict):
+            return RunBudgetUsage()
+        total = token_usage.get("total")
+        if not isinstance(total, dict):
+            return RunBudgetUsage()
+        return RunBudgetUsage(
+            spent_tokens=int(total.get("totalTokens") or 0),
+            spent_cost_usd=0.0,
+            wall_minutes=0,
+        )
+
     def _build_exec_prompt(self, request: RunLaunchRequest) -> str:
         run_brief_path = Path(request.artifacts_path) / "context" / "compiled" / "run-brief.md"
         run_brief = run_brief_path.read_text(encoding="utf-8")
@@ -89,6 +131,111 @@ class CodexDriver(HarnessDriver):
                 "summary of what changed and any remaining risks.",
                 run_brief.strip(),
             ]
+        )
+
+    def _launch_live_app_server(self, request: RunLaunchRequest) -> RunHandle | None:
+        binary_name, binary_path = self._detected_binary_details()
+        if not self._live_app_server_enabled() or not binary_path:
+            return None
+
+        help_text = self._command_output("--help") or ""
+        app_server_help = self._command_output("app-server", "--help") or ""
+        if "app-server" not in help_text or "--listen" not in app_server_help:
+            return None
+
+        run_root = Path(request.artifacts_path)
+        raw_output_path = run_root / "transcript" / "raw" / "codex-app-server-events.jsonl"
+        last_message_path = run_root / "transcript" / "raw" / "codex-app-server-last-message.txt"
+        exit_code_path = run_root / "driver" / "codex-app-server-exit.txt"
+        state_path = run_root / "driver" / "codex-app-server-state.json"
+        prompt_path = run_root / "driver" / "codex-app-server-prompt.txt"
+        command_path = run_root / "driver" / "codex-app-server-command.txt"
+        stderr_path = run_root / "logs" / "stderr.txt"
+        raw_output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            prompt = self._build_exec_prompt(request)
+        except OSError as exc:
+            return RunHandle(
+                run_id=request.run_id,
+                driver=self.name,
+                driver_handle=f"{self.name}:app-server:{request.run_id}",
+                status="failed",
+                launched_at=utc_now_iso(),
+                launch_mode="app_server",
+                transport="stdio-jsonrpc",
+                metadata={"launch_error": str(exc)},
+            )
+
+        prompt_path.write_text(prompt, encoding="utf-8")
+        worker_path = Path(__file__).with_name("codex_app_server_worker.py")
+        command = [
+            sys.executable,
+            str(worker_path),
+            "--binary",
+            binary_path,
+            "--worktree",
+            request.workspace.worktree_path,
+            "--prompt",
+            str(prompt_path),
+            "--raw-output",
+            str(raw_output_path),
+            "--last-message",
+            str(last_message_path),
+            "--exit-code",
+            str(exit_code_path),
+            "--stderr",
+            str(stderr_path),
+            "--approval-channel",
+            str(request.metadata.get("approval_channel") or ""),
+            "--state",
+            str(state_path),
+        ]
+        if request.model:
+            command.extend(["--model", request.model])
+        command_path.write_text(" ".join(shlex.quote(part) for part in command), encoding="utf-8")
+        try:
+            process = subprocess.Popen(
+                command,
+                cwd=request.workspace.worktree_path,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                start_new_session=True,
+            )
+        except OSError as exc:
+            return RunHandle(
+                run_id=request.run_id,
+                driver=self.name,
+                driver_handle=f"{self.name}:app-server:{request.run_id}",
+                status="failed",
+                launched_at=utc_now_iso(),
+                launch_mode="app_server",
+                transport="stdio-jsonrpc",
+                metadata={"launch_error": str(exc)},
+            )
+        return RunHandle(
+            run_id=request.run_id,
+            driver=self.name,
+            driver_handle=f"{self.name}:app-server:{process.pid}",
+            status="running",
+            launched_at=utc_now_iso(),
+            launch_mode="app_server",
+            transport="stdio-jsonrpc",
+            session_id=str(process.pid),
+            event_cursor="0",
+            approval_channel=str(request.metadata.get("approval_channel") or "") or None,
+            metadata={
+                "binary_name": binary_name,
+                "binary_path": binary_path,
+                "pid": process.pid,
+                "raw_output_path": str(raw_output_path),
+                "last_message_path": str(last_message_path),
+                "exit_code_path": str(exit_code_path),
+                "state_path": str(state_path),
+                "prompt_path": str(prompt_path),
+                "command_path": str(command_path),
+            },
         )
 
     @staticmethod
@@ -276,7 +423,32 @@ class CodexDriver(HarnessDriver):
         snapshot = info.capability_snapshot
         if snapshot is None:
             return info
-        if self._live_exec_enabled() and snapshot.probed.get("exec_available"):
+        if self._live_app_server_enabled() and snapshot.probed.get("app_server_available"):
+            snapshot.effective = capability_surface(
+                launch_mode="app_server",
+                session_persistence="thread",
+                event_stream="structured_deltas",
+                approvals=["command", "file"],
+                skills="file_projection",
+                worktrees="host_managed",
+                subagents="none",
+                native_sandbox="policy",
+                outer_sandbox_required=True,
+                artifacts=["runpack", "transcript", "plan", "diff"],
+                reroute_export="transcript",
+            )
+            snapshot.confidence["effective"] = "verified"
+            snapshot.evidence["effective"] = (
+                "Codex app-server mode is enabled, so Hive can launch a real interactive "
+                "Codex session over stdio JSON-RPC."
+            )
+            info.capabilities.resume = False
+            info.capabilities.interrupt = ["cancel"]
+            info.capabilities.reroute_export = "transcript"
+            info.notes.append(
+                "Codex app-server mode is enabled; Hive can launch a live interactive Codex run."
+            )
+        elif self._live_exec_enabled() and snapshot.probed.get("exec_available"):
             snapshot.effective = capability_surface(
                 launch_mode="exec",
                 session_persistence="ephemeral",
@@ -304,12 +476,150 @@ class CodexDriver(HarnessDriver):
         return info
 
     def launch(self, request: RunLaunchRequest) -> RunHandle:
+        app_server_handle = self._launch_live_app_server(request)
+        if app_server_handle is not None:
+            return app_server_handle
         live_handle = self._launch_live_exec(request)
         if live_handle is not None:
             return live_handle
         return super().launch(request)
 
     def status(self, handle: RunHandle) -> RunStatus:
+        if handle.launch_mode == "app_server":
+            raw_output_path = str(handle.metadata.get("raw_output_path") or "")
+            last_message_path = str(handle.metadata.get("last_message_path") or "")
+            exit_code_path = str(handle.metadata.get("exit_code_path") or "")
+            state_path = str(handle.metadata.get("state_path") or "")
+            pid = int(handle.metadata.get("pid") or 0)
+            exit_code = self._read_exit_code(exit_code_path)
+            state = self._load_state(state_path)
+            budget = self._budget_usage_from_state(state)
+            cursor = self._event_cursor(raw_output_path) or handle.event_cursor
+            last_event_at = self._last_event_timestamp(
+                raw_output_path,
+                last_message_path,
+                state_path,
+                exit_code_path,
+            )
+            turn_status = str(state.get("turn_status") or "")
+            thread_status = str(state.get("thread_status") or "")
+            session = {
+                "launch_mode": "app_server",
+                "transport": "stdio-jsonrpc",
+                "session_id": handle.session_id,
+                "thread_id": state.get("thread_id"),
+                "turn_id": state.get("turn_id"),
+                "pid": pid or None,
+            }
+            artifacts = {
+                "raw_output_path": raw_output_path or None,
+                "last_message_path": last_message_path or None,
+                "exit_code_path": exit_code_path or None,
+                "state_path": state_path or None,
+            }
+            if exit_code is None:
+                if pid and self._pid_is_running(pid):
+                    message = "Codex app-server is actively working in the Hive run worktree."
+                    phase = "implementing"
+                    percent = 20
+                    if thread_status == "idle" and turn_status == "inProgress":
+                        message = "Codex app-server is wrapping up the current turn."
+                    elif turn_status == "completed":
+                        message = (
+                            "Codex app-server finished the turn and is draining final events "
+                            "before Hive marks the run complete."
+                        )
+                        phase = "finalizing"
+                        percent = 95
+                    elif turn_status in {"cancelled", "interrupted"}:
+                        message = (
+                            "Codex app-server acknowledged the interrupt and is finalizing "
+                            "shutdown artifacts."
+                        )
+                        phase = "cancelling"
+                        percent = 95
+                    return RunStatus(
+                        run_id=handle.run_id,
+                        state="running",
+                        health="healthy",
+                        driver=self.name,
+                        progress=RunProgress(
+                            phase=phase,
+                            message=message,
+                            percent=percent,
+                        ),
+                        waiting_on=None,
+                        last_event_at=last_event_at or handle.launched_at,
+                        budget=budget,
+                        event_cursor=cursor,
+                        session=session,
+                        artifacts=artifacts,
+                    )
+                return RunStatus(
+                    run_id=handle.run_id,
+                    state="failed",
+                    health="failed",
+                    driver=self.name,
+                    progress=RunProgress(
+                        phase="failed",
+                        message="Codex app-server stopped without writing an exit marker.",
+                        percent=100,
+                    ),
+                    waiting_on="operator",
+                    last_event_at=last_event_at or handle.launched_at,
+                    budget=budget,
+                    event_cursor=cursor,
+                    session=session,
+                    artifacts=artifacts,
+                )
+            if exit_code == 0:
+                state_name = "completed_candidate"
+                health = "healthy"
+                waiting_on = "review"
+                progress = RunProgress(
+                    phase="completed",
+                    message="Codex app-server finished and produced a candidate result for review.",
+                    percent=100,
+                )
+                if turn_status in {"cancelled", "interrupted"}:
+                    state_name = "cancelled"
+                    health = "needs_attention"
+                    waiting_on = "operator"
+                    progress = RunProgress(
+                        phase="cancelled",
+                        message="Codex app-server turn was interrupted by Hive.",
+                        percent=100,
+                    )
+                return RunStatus(
+                    run_id=handle.run_id,
+                    state=state_name,
+                    health=health,
+                    driver=self.name,
+                    progress=progress,
+                    waiting_on=waiting_on,
+                    last_event_at=last_event_at or handle.launched_at,
+                    budget=budget,
+                    event_cursor=cursor,
+                    session=session,
+                    artifacts=artifacts,
+                )
+            return RunStatus(
+                run_id=handle.run_id,
+                state="failed",
+                health="failed",
+                driver=self.name,
+                progress=RunProgress(
+                    phase="failed",
+                    message=f"Codex app-server bridge exited with status {exit_code}.",
+                    percent=100,
+                ),
+                waiting_on="operator",
+                last_event_at=last_event_at or handle.launched_at,
+                budget=budget,
+                event_cursor=cursor,
+                session=session,
+                artifacts=artifacts,
+            )
         if handle.launch_mode != "exec":
             return super().status(handle)
 
@@ -404,6 +714,38 @@ class CodexDriver(HarnessDriver):
         )
 
     def interrupt(self, handle: RunHandle, mode: str) -> dict[str, Any]:
+        if handle.launch_mode == "app_server":
+            if mode != "cancel":
+                return super().interrupt(handle, mode)
+            channel_path = str(handle.approval_channel or handle.metadata.get("approval_channel") or "")
+            if not channel_path.strip():
+                return {
+                    "ok": False,
+                    "driver": self.name,
+                    "run_id": handle.run_id,
+                    "mode": mode,
+                    "message": "Codex app-server handle does not expose a control channel.",
+                }
+            target = Path(channel_path)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            record = {
+                "ts": utc_now_iso(),
+                "kind": "interrupt_request",
+                "driver": self.name,
+                "run_id": handle.run_id,
+                "driver_handle": handle.driver_handle,
+                "mode": mode,
+            }
+            with open(target, "a", encoding="utf-8") as handle_out:
+                handle_out.write(json.dumps(record, sort_keys=True) + "\n")
+            return {
+                "ok": True,
+                "driver": self.name,
+                "run_id": handle.run_id,
+                "mode": mode,
+                "channel": str(target),
+                "message": "Queued a Codex app-server interrupt request.",
+            }
         if handle.launch_mode != "exec":
             return super().interrupt(handle, mode)
         pid = int(handle.metadata.get("pid") or 0)
@@ -443,6 +785,17 @@ class CodexDriver(HarnessDriver):
         }
 
     def collect_artifacts(self, handle: RunHandle) -> dict[str, Any]:
+        if handle.launch_mode == "app_server":
+            return {
+                "driver": self.name,
+                "run_id": handle.run_id,
+                "artifacts": [
+                    handle.metadata.get("raw_output_path"),
+                    handle.metadata.get("last_message_path"),
+                    handle.metadata.get("exit_code_path"),
+                    handle.metadata.get("state_path"),
+                ],
+            }
         if handle.launch_mode != "exec":
             return super().collect_artifacts(handle)
         return {

--- a/src/hive/drivers/codex_app_server_worker.py
+++ b/src/hive/drivers/codex_app_server_worker.py
@@ -1,0 +1,421 @@
+"""Background bridge for Codex app-server runs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import selectors
+import subprocess
+import sys
+import time
+from typing import Any
+
+
+def _append_ndjson(path: Path, record: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def _load_channel_records(path: Path, cursor: int) -> tuple[list[dict[str, Any]], int]:
+    if not path.exists():
+        return [], cursor
+    with open(path, "r", encoding="utf-8") as handle:
+        lines = [line for line in handle.read().splitlines() if line.strip()]
+    records: list[dict[str, Any]] = []
+    for raw_line in lines[cursor:]:
+        try:
+            payload = json.loads(raw_line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            records.append(payload)
+    return records, len(lines)
+
+
+class CodexAppServerBroker:
+    """Small stdio JSON-RPC broker that keeps Codex attached to a Hive run."""
+
+    def __init__(self, args: argparse.Namespace) -> None:
+        self.binary_path = str(args.binary)
+        self.worktree_path = Path(args.worktree).resolve()
+        self.prompt_path = Path(args.prompt).resolve()
+        self.raw_output_path = Path(args.raw_output).resolve()
+        self.last_message_path = Path(args.last_message).resolve()
+        self.exit_code_path = Path(args.exit_code).resolve()
+        self.stderr_path = Path(args.stderr).resolve()
+        self.approval_channel_path = Path(args.approval_channel).resolve()
+        self.state_path = Path(args.state).resolve()
+        self.model = str(args.model or "").strip() or None
+        self.process: subprocess.Popen[bytes] | None = None
+        self.selector = selectors.DefaultSelector()
+        self.responses: dict[str, dict[str, Any]] = {}
+        self.pending_requests: dict[str, dict[str, Any]] = {}
+        self.pending_interrupt = False
+        self.driver_channel_cursor = 0
+        self.request_id = 0
+        self.stdout_buffer = b""
+        self.state: dict[str, Any] = {
+            "thread_id": None,
+            "thread_status": None,
+            "turn_id": None,
+            "turn_status": None,
+            "token_usage": {},
+            "last_message": None,
+        }
+
+    def _write_state(self) -> None:
+        self.state_path.parent.mkdir(parents=True, exist_ok=True)
+        self.state_path.write_text(
+            json.dumps(self.state, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+
+    def _write_exit_code(self, code: int) -> None:
+        self.exit_code_path.parent.mkdir(parents=True, exist_ok=True)
+        self.exit_code_path.write_text(f"{code}\n", encoding="utf-8")
+
+    def _next_request_id(self) -> int:
+        self.request_id += 1
+        return self.request_id
+
+    def _send(self, payload: dict[str, Any]) -> None:
+        if self.process is None or self.process.stdin is None:
+            raise RuntimeError("Codex app-server process is not writable")
+        self.process.stdin.write((json.dumps(payload, sort_keys=True) + "\n").encode("utf-8"))
+        self.process.stdin.flush()
+
+    def _approval_key(self, request_id: object, method: str, params: dict[str, Any]) -> str:
+        if method == "item/commandExecution/requestApproval":
+            for key in ("approvalId", "itemId"):
+                value = params.get(key)
+                if value:
+                    return str(value)
+        if method == "item/fileChange/requestApproval":
+            value = params.get("itemId")
+            if value:
+                return str(value)
+        if method == "execCommandApproval":
+            value = params.get("approvalId") or params.get("callId")
+            if value:
+                return str(value)
+        if method == "applyPatchApproval":
+            value = params.get("callId")
+            if value:
+                return str(value)
+        return str(request_id)
+
+    def _command_resolution_result(self, resolution: str) -> dict[str, Any]:
+        decision = "accept" if resolution == "approved" else "decline"
+        return {"decision": decision}
+
+    def _legacy_resolution_result(self, resolution: str) -> dict[str, Any]:
+        decision = "approved" if resolution == "approved" else "denied"
+        return {"decision": decision}
+
+    def _resolution_result(self, method: str, resolution: str) -> dict[str, Any]:
+        if method in {"item/commandExecution/requestApproval", "item/fileChange/requestApproval"}:
+            return self._command_resolution_result(resolution)
+        return self._legacy_resolution_result(resolution)
+
+    def _handle_server_request(self, message: dict[str, Any]) -> None:
+        request_id = message.get("id")
+        method = str(message.get("method") or "")
+        params = dict(message.get("params") or {})
+        key = self._approval_key(request_id, method, params)
+        self.pending_requests[key] = {
+            "id": request_id,
+            "method": method,
+            "params": params,
+        }
+        _append_ndjson(self.raw_output_path, message)
+
+    def _update_last_message(self, text: str | None) -> None:
+        if not text:
+            return
+        self.state["last_message"] = text
+        self.last_message_path.parent.mkdir(parents=True, exist_ok=True)
+        self.last_message_path.write_text(text + "\n", encoding="utf-8")
+
+    def _handle_notification(self, message: dict[str, Any]) -> None:
+        method = str(message.get("method") or "")
+        params = dict(message.get("params") or {})
+        if method.startswith("codex/event/"):
+            return
+        if method == "thread/started":
+            thread = dict(params.get("thread") or {})
+            self.state["thread_id"] = thread.get("id")
+            status = dict(thread.get("status") or {})
+            self.state["thread_status"] = status.get("type") or thread.get("status")
+        elif method == "thread/status/changed":
+            status = dict(params.get("status") or {})
+            self.state["thread_id"] = params.get("threadId") or self.state.get("thread_id")
+            self.state["thread_status"] = status.get("type") or params.get("status")
+        elif method == "turn/started":
+            turn = dict(params.get("turn") or {})
+            self.state["thread_id"] = params.get("threadId") or self.state.get("thread_id")
+            self.state["turn_id"] = turn.get("id") or self.state.get("turn_id")
+            self.state["turn_status"] = turn.get("status") or "inProgress"
+        elif method == "turn/completed":
+            turn = dict(params.get("turn") or {})
+            self.state["thread_id"] = params.get("threadId") or self.state.get("thread_id")
+            self.state["turn_id"] = turn.get("id") or self.state.get("turn_id")
+            self.state["turn_status"] = turn.get("status") or "completed"
+        elif method == "thread/tokenUsage/updated":
+            token_usage = dict(params.get("tokenUsage") or {})
+            self.state["token_usage"] = token_usage
+        elif method == "item/completed":
+            item = dict(params.get("item") or {})
+            if item.get("type") == "agentMessage":
+                self._update_last_message(str(item.get("text") or "").strip() or None)
+        _append_ndjson(self.raw_output_path, message)
+        self._write_state()
+
+    def _process_message(self, line: str) -> None:
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError:
+            return
+        if not isinstance(message, dict):
+            return
+        if "method" in message and "params" in message:
+            method = str(message.get("method") or "")
+            if method in {
+                "item/commandExecution/requestApproval",
+                "item/fileChange/requestApproval",
+                "execCommandApproval",
+                "applyPatchApproval",
+            }:
+                self._handle_server_request(message)
+                return
+            self._handle_notification(message)
+            return
+        if "id" in message and ("result" in message or "error" in message):
+            self.responses[str(message.get("id"))] = message
+
+    def _pump_messages(self, timeout: float) -> None:
+        if self.process is None or self.process.stdout is None:
+            return
+        for key, _ in self.selector.select(timeout):
+            fd = key.fileobj.fileno()
+            while True:
+                try:
+                    chunk = os.read(fd, 65536)
+                except BlockingIOError:
+                    break
+                if not chunk:
+                    break
+                self.stdout_buffer += chunk
+                while b"\n" in self.stdout_buffer:
+                    raw_line, self.stdout_buffer = self.stdout_buffer.split(b"\n", 1)
+                    line = raw_line.decode("utf-8", errors="replace").strip()
+                    if line:
+                        self._process_message(line)
+                if len(chunk) < 65536:
+                    break
+
+    def _wait_for_response(self, request_id: int, *, timeout: float = 15.0) -> dict[str, Any]:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            self._pump_messages(0.2)
+            self._check_driver_channel()
+            response = self.responses.pop(str(request_id), None)
+            if response is not None:
+                return response
+            if self.process is not None and self.process.poll() is not None:
+                raise RuntimeError("Codex app-server exited before responding")
+        raise TimeoutError(f"Timed out waiting for app-server response {request_id}")
+
+    def _send_interrupt(self) -> None:
+        if not self.pending_interrupt:
+            return
+        thread_id = str(self.state.get("thread_id") or "").strip()
+        turn_id = str(self.state.get("turn_id") or "").strip()
+        if not thread_id or not turn_id:
+            return
+        request_id = self._next_request_id()
+        self._send(
+            {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": "turn/interrupt",
+                "params": {"threadId": thread_id, "turnId": turn_id},
+            }
+        )
+        self.pending_interrupt = False
+
+    def _respond_to_pending_request(self, record: dict[str, Any]) -> None:
+        payload = dict(record.get("payload") or {})
+        resolution = str(record.get("resolution") or "")
+        for candidate in (
+            payload.get("approval_id"),
+            payload.get("item_id"),
+            payload.get("server_request_id"),
+            payload.get("call_id"),
+        ):
+            key = str(candidate or "").strip()
+            if not key:
+                continue
+            pending = self.pending_requests.pop(key, None)
+            if pending is None:
+                continue
+            self._send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": pending["id"],
+                    "result": self._resolution_result(str(pending["method"]), resolution),
+                }
+            )
+            return
+
+    def _check_driver_channel(self) -> None:
+        records, next_cursor = _load_channel_records(
+            self.approval_channel_path,
+            self.driver_channel_cursor,
+        )
+        self.driver_channel_cursor = next_cursor
+        for record in records:
+            kind = str(record.get("kind") or "")
+            if kind == "approval_resolution":
+                self._respond_to_pending_request(record)
+            elif kind == "interrupt_request":
+                self.pending_interrupt = True
+        self._send_interrupt()
+
+    def run(self) -> int:
+        prompt = self.prompt_path.read_text(encoding="utf-8")
+        self.raw_output_path.parent.mkdir(parents=True, exist_ok=True)
+        self.last_message_path.parent.mkdir(parents=True, exist_ok=True)
+        self.stderr_path.parent.mkdir(parents=True, exist_ok=True)
+        self.approval_channel_path.parent.mkdir(parents=True, exist_ok=True)
+        self._write_state()
+
+        with open(self.stderr_path, "a", encoding="utf-8") as stderr_handle:
+            process = subprocess.Popen(
+                [self.binary_path, "app-server", "--listen", "stdio://"],
+                cwd=str(self.worktree_path),
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=stderr_handle,
+                bufsize=0,
+            )
+            self.process = process
+            assert process.stdout is not None
+            os.set_blocking(process.stdout.fileno(), False)
+            self.selector.register(process.stdout, selectors.EVENT_READ)
+            try:
+                initialize_id = self._next_request_id()
+                self._send(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": initialize_id,
+                        "method": "initialize",
+                        "params": {
+                            "clientInfo": {"name": "hive", "title": "Hive", "version": "2.3.0"},
+                            "capabilities": None,
+                        },
+                    }
+                )
+                self._wait_for_response(initialize_id)
+
+                thread_start_id = self._next_request_id()
+                thread_params: dict[str, Any] = {
+                    "cwd": str(self.worktree_path),
+                    "approvalPolicy": "on-request",
+                    "sandbox": "workspace-write",
+                    "ephemeral": False,
+                    "personality": "pragmatic",
+                }
+                if self.model:
+                    thread_params["model"] = self.model
+                self._send(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": thread_start_id,
+                        "method": "thread/start",
+                        "params": thread_params,
+                    }
+                )
+                thread_response = self._wait_for_response(thread_start_id)
+                thread = dict((thread_response.get("result") or {}).get("thread") or {})
+                self.state["thread_id"] = thread.get("id")
+                self.state["thread_status"] = dict(thread.get("status") or {}).get("type") or thread.get(
+                    "status"
+                )
+                self._write_state()
+
+                turn_start_id = self._next_request_id()
+                self._send(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": turn_start_id,
+                        "method": "turn/start",
+                        "params": {
+                            "threadId": self.state["thread_id"],
+                            "input": [{"type": "text", "text": prompt}],
+                        },
+                    }
+                )
+                turn_response = self._wait_for_response(turn_start_id)
+                turn = dict((turn_response.get("result") or {}).get("turn") or {})
+                self.state["turn_id"] = turn.get("id")
+                self.state["turn_status"] = turn.get("status") or "inProgress"
+                self._write_state()
+
+                completed_at: float | None = None
+                while True:
+                    self._pump_messages(0.2)
+                    self._check_driver_channel()
+                    if process.poll() is not None:
+                        break
+                    if self.state.get("turn_status") in {"completed", "interrupted", "cancelled", "failed"}:
+                        if completed_at is None:
+                            completed_at = time.monotonic()
+                        elif time.monotonic() - completed_at >= 0.5 and not self.pending_requests:
+                            break
+                    else:
+                        completed_at = None
+                return 0
+            except Exception as exc:  # pragma: no cover - defensive runtime reporting
+                _append_ndjson(
+                    self.raw_output_path,
+                    {"method": "hive/error", "params": {"message": str(exc)}},
+                )
+                return 1
+            finally:
+                self.selector.close()
+                if process.poll() is None:
+                    process.terminate()
+                    try:
+                        process.wait(timeout=2)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        process.wait(timeout=2)
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Codex app-server bridge for Hive runs.")
+    parser.add_argument("--binary", required=True, type=Path)
+    parser.add_argument("--worktree", required=True, type=Path)
+    parser.add_argument("--prompt", required=True, type=Path)
+    parser.add_argument("--raw-output", required=True, type=Path)
+    parser.add_argument("--last-message", required=True, type=Path)
+    parser.add_argument("--exit-code", required=True, type=Path)
+    parser.add_argument("--stderr", required=True, type=Path)
+    parser.add_argument("--approval-channel", required=True, type=Path)
+    parser.add_argument("--state", required=True, type=Path)
+    parser.add_argument("--model", default=None)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    broker = CodexAppServerBroker(_parse_args(list(argv or sys.argv[1:])))
+    exit_code = broker.run()
+    broker._write_exit_code(exit_code)
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/hive/runs/driver_state.py
+++ b/src/hive/runs/driver_state.py
@@ -286,6 +286,85 @@ def _request_codex_approval(
     return approval
 
 
+def _request_codex_app_server_command_approval(
+    root: Path,
+    metadata: dict,
+    *,
+    request_id: object,
+    payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    imports = _driver_imports(metadata)
+    seen_ids = imports.setdefault("app_server_command_approval_ids", [])
+    approval_key = str(payload.get("approvalId") or payload.get("itemId") or request_id or "")
+    if approval_key and approval_key in seen_ids:
+        return None
+    command_text = str(payload.get("command") or payload.get("itemId") or "command")
+    approval = request_approval(
+        root,
+        str(metadata["id"]),
+        kind="command",
+        title=f"Approve Codex command: {command_text}",
+        summary=f"Codex requested approval to execute `{command_text}` through app-server.",
+        requested_by="driver:codex",
+        payload={
+            "server_request_id": str(request_id),
+            "approval_id": payload.get("approvalId"),
+            "item_id": payload.get("itemId"),
+            "thread_id": payload.get("threadId"),
+            "turn_id": payload.get("turnId"),
+            "command": payload.get("command"),
+            "cwd": payload.get("cwd"),
+            "reason": payload.get("reason"),
+            "command_actions": payload.get("commandActions"),
+        },
+    )
+    metadata.setdefault("metadata_json", {}).setdefault("approvals", []).append(approval)
+    if approval_key:
+        seen_ids.append(approval_key)
+    return approval
+
+
+def _request_codex_app_server_file_approval(
+    root: Path,
+    metadata: dict,
+    *,
+    request_id: object,
+    payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    imports = _driver_imports(metadata)
+    seen_ids = imports.setdefault("app_server_file_approval_ids", [])
+    approval_key = str(payload.get("itemId") or payload.get("callId") or request_id or "")
+    if approval_key and approval_key in seen_ids:
+        return None
+    grant_root = str(payload.get("grantRoot") or "").strip()
+    reason = str(payload.get("reason") or "").strip()
+    title = "Approve Codex file change"
+    if grant_root:
+        title = f"Approve Codex write access: {grant_root}"
+    approval = request_approval(
+        root,
+        str(metadata["id"]),
+        kind="file",
+        title=title,
+        summary=reason or "Codex requested permission to apply file changes.",
+        requested_by="driver:codex",
+        payload={
+            "server_request_id": str(request_id),
+            "item_id": payload.get("itemId"),
+            "call_id": payload.get("callId"),
+            "thread_id": payload.get("threadId") or payload.get("conversationId"),
+            "turn_id": payload.get("turnId"),
+            "grant_root": payload.get("grantRoot"),
+            "reason": payload.get("reason"),
+            "file_changes": payload.get("fileChanges"),
+        },
+    )
+    metadata.setdefault("metadata_json", {}).setdefault("approvals", []).append(approval)
+    if approval_key:
+        seen_ids.append(approval_key)
+    return approval
+
+
 def _emit_runtime_driver_event(
     root: Path,
     metadata: dict,
@@ -432,6 +511,158 @@ def _ingest_codex_exec_events(
         status_payload["progress"] = progress
 
 
+def _thread_token_usage_payload(payload: dict[str, Any]) -> dict[str, Any] | None:
+    token_usage = payload.get("tokenUsage")
+    if not isinstance(token_usage, dict):
+        return None
+    total = token_usage.get("total")
+    if not isinstance(total, dict):
+        return None
+    return {
+        "total_tokens": total.get("totalTokens"),
+        "input_tokens": total.get("inputTokens"),
+        "cached_input_tokens": total.get("cachedInputTokens"),
+        "output_tokens": total.get("outputTokens"),
+        "reasoning_output_tokens": total.get("reasoningOutputTokens"),
+    }
+
+
+def _ingest_codex_app_server_events(
+    root: Path,
+    metadata: dict,
+    handle: RunHandle,
+    status_payload: dict[str, object],
+) -> None:
+    if str(metadata.get("driver")) != "codex" or handle.launch_mode != "app_server":
+        return
+    artifacts = status_payload.get("artifacts")
+    if not isinstance(artifacts, dict):
+        return
+    raw_output_path = artifacts.get("raw_output_path") or handle.metadata.get("raw_output_path")
+    if not isinstance(raw_output_path, str) or not raw_output_path.strip():
+        return
+    raw_path = Path(raw_output_path)
+    if not raw_path.exists():
+        return
+
+    imports = _driver_imports(metadata)
+    previous_cursor = _coerce_line_cursor(
+        handle.event_cursor or imports.get("codex_app_server_event_cursor") or 0
+    )
+    current_cursor = _coerce_line_cursor(status_payload.get("event_cursor"))
+    raw_lines = [line for line in raw_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    if current_cursor <= 0:
+        current_cursor = len(raw_lines)
+    new_records = raw_lines[previous_cursor:current_cursor]
+
+    for raw_line in new_records:
+        try:
+            record = json.loads(raw_line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(record, dict):
+            continue
+        method = str(record.get("method") or "")
+        payload = dict(record.get("params") or {})
+        if not method:
+            continue
+        source = "driver.codex.app_server"
+        if method == "item/agentMessage/delta":
+            text = str(payload.get("delta") or "").strip()
+            if text:
+                _append_transcript_entry(
+                    Path(metadata["transcript_path"]),
+                    {
+                        "ts": utc_now_iso(),
+                        "kind": "assistant",
+                        "driver": metadata.get("driver"),
+                        "message": text,
+                        "driver_event_type": method,
+                    },
+                )
+                _emit_runtime_driver_event(
+                    root,
+                    metadata,
+                    event_type="driver.output.delta",
+                    source=source,
+                    payload={"driver_event_type": method, "message": text},
+                )
+            continue
+        if method in {"item/reasoning/textDelta", "item/reasoning/summaryTextDelta"}:
+            text = str(payload.get("delta") or "").strip()
+            if text:
+                _append_transcript_entry(
+                    Path(metadata["transcript_path"]),
+                    {
+                        "ts": utc_now_iso(),
+                        "kind": "thinking",
+                        "driver": metadata.get("driver"),
+                        "message": text,
+                        "driver_event_type": method,
+                    },
+                )
+            continue
+        if method == "item/commandExecution/requestApproval":
+            _request_codex_app_server_command_approval(
+                root,
+                metadata,
+                request_id=record.get("id"),
+                payload=payload,
+            )
+            continue
+        if method in {"item/fileChange/requestApproval", "applyPatchApproval"}:
+            _request_codex_app_server_file_approval(
+                root,
+                metadata,
+                request_id=record.get("id"),
+                payload=payload,
+            )
+            continue
+        if method == "turn/plan/updated":
+            _emit_runtime_driver_event(
+                root,
+                metadata,
+                event_type="plan.updated",
+                source=source,
+                payload={"driver_event_type": method, "payload": payload},
+            )
+            continue
+        if method == "turn/diff/updated":
+            _emit_runtime_driver_event(
+                root,
+                metadata,
+                event_type="diff.updated",
+                source=source,
+                payload={"driver_event_type": method, "payload": payload},
+            )
+            continue
+        usage = _thread_token_usage_payload(payload)
+        if usage is not None:
+            _record_driver_usage(metadata, status_payload, usage)
+        _emit_runtime_driver_event(
+            root,
+            metadata,
+            event_type="driver.status",
+            source=source,
+            payload={"driver_event_type": method, "payload": payload},
+        )
+
+    imports["codex_app_server_event_cursor"] = current_cursor
+    imports["codex_app_server_raw_output_path"] = str(raw_path)
+    pending = pending_approvals(root, str(metadata["id"]))
+    status_payload["pending_approvals"] = pending
+    if pending and status_payload.get("state") == "running":
+        status_payload["health"] = "blocked"
+        status_payload["waiting_on"] = "approval"
+        progress = dict(status_payload.get("progress") or {})
+        if not progress:
+            progress = {"phase": "waiting", "message": "Awaiting driver approval.", "percent": 0}
+        else:
+            progress["phase"] = "waiting"
+            progress["message"] = "Codex is blocked on a pending approval request."
+        status_payload["progress"] = progress
+
+
 def _update_active_handle_from_status(metadata: dict, status_payload: dict[str, object]) -> None:
     handles = _load_driver_handles(metadata)
     active = handles.get("active")
@@ -500,6 +731,7 @@ def _refresh_live_driver_status(root: Path, metadata: dict) -> dict[str, object]
     status = driver.status(handle)
     status_payload = status.to_dict()
     _ingest_codex_exec_events(root, metadata, handle, status_payload)
+    _ingest_codex_app_server_events(root, metadata, handle, status_payload)
     _sync_run_budget_from_status(metadata, status_payload)
     _record_driver_status(metadata, status_payload)
     _update_active_handle_from_status(metadata, status_payload)

--- a/tests/test_hive_drivers.py
+++ b/tests/test_hive_drivers.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 import subprocess
+import tempfile
+import time
 
 from tests.conftest import init_git_repo, write_safe_program
 from hive.cli.main import main as hive_main
@@ -41,6 +43,189 @@ def _invoke_cli_json(capsys, argv: list[str]) -> dict:
     captured = capsys.readouterr()
     assert exit_code == 0
     return json.loads(captured.out)
+
+
+def _write_fake_codex_binary(base_dir: str) -> Path:
+    temp_dir = Path(tempfile.mkdtemp(prefix="fake-codex-"))
+    target = temp_dir / "fake-codex.py"
+    target.write_text(
+        """#!/usr/bin/env python3
+import json
+import sys
+
+
+def send(payload):
+    sys.stdout.write(json.dumps(payload, sort_keys=True) + "\\n")
+    sys.stdout.flush()
+
+
+def main():
+    args = sys.argv[1:]
+    if args == ["--help"]:
+        sys.stdout.write("Codex CLI\\nCommands:\\n  exec\\n  app-server\\n")
+        return 0
+    if args == ["--version"]:
+        sys.stdout.write("codex 0.0.0-test\\n")
+        return 0
+    if args[:2] == ["app-server", "--help"]:
+        sys.stdout.write("Usage: codex app-server --listen <URL>\\n  --listen <URL>\\n")
+        return 0
+    if args[:3] != ["app-server", "--listen", "stdio://"]:
+        return 2
+
+    thread_id = "thread_test"
+    turn_id = "turn_test"
+    approval_request_id = 9001
+
+    for raw_line in sys.stdin:
+        line = raw_line.strip()
+        if not line:
+            continue
+        message = json.loads(line)
+        method = message.get("method")
+        if method == "initialize":
+            send({"id": message["id"], "result": {"userAgent": "fake-codex"}})
+        elif method == "thread/start":
+            send(
+                {
+                    "id": message["id"],
+                    "result": {
+                        "thread": {"id": thread_id, "status": {"type": "idle"}},
+                        "model": "gpt-5.4",
+                        "modelProvider": "openai",
+                        "cwd": ".",
+                        "approvalPolicy": "on-request",
+                        "sandbox": {"type": "workspaceWrite"},
+                    },
+                }
+            )
+            send({"method": "thread/started", "params": {"thread": {"id": thread_id, "status": {"type": "idle"}}}})
+            send({"method": "thread/status/changed", "params": {"threadId": thread_id, "status": {"type": "idle"}}})
+        elif method == "turn/start":
+            prompt = " ".join(
+                item.get("text", "")
+                for item in message.get("params", {}).get("input", [])
+                if isinstance(item, dict)
+            )
+            send(
+                {
+                    "id": message["id"],
+                    "result": {"turn": {"id": turn_id, "items": [], "status": "inProgress", "error": None}},
+                }
+            )
+            send(
+                {
+                    "method": "turn/started",
+                    "params": {"threadId": thread_id, "turn": {"id": turn_id, "items": [], "status": "inProgress", "error": None}},
+                }
+            )
+            send({"method": "thread/status/changed", "params": {"threadId": thread_id, "status": {"type": "active", "activeFlags": []}}})
+            if "WAIT_FOR_INTERRUPT" in prompt:
+                continue
+            send({"method": "item/agentMessage/delta", "params": {"threadId": thread_id, "turnId": turn_id, "itemId": "msg_1", "delta": "Working"}})
+            send({"method": "turn/plan/updated", "params": {"threadId": thread_id, "turnId": turn_id, "explanation": "Inspect repo", "plan": [{"step": "Inspect repo", "status": "inProgress"}]}})
+            send(
+                {
+                    "method": "item/commandExecution/requestApproval",
+                    "id": approval_request_id,
+                    "params": {
+                        "threadId": thread_id,
+                        "turnId": turn_id,
+                        "itemId": "cmd_1",
+                        "approvalId": "appr_1",
+                        "command": "git status",
+                        "cwd": ".",
+                        "reason": "Need repo status",
+                    },
+                }
+            )
+        elif method == "turn/interrupt":
+            send({"id": message["id"], "result": {}})
+            send({"method": "thread/status/changed", "params": {"threadId": thread_id, "status": {"type": "idle"}}})
+            send(
+                {
+                    "method": "thread/tokenUsage/updated",
+                    "params": {
+                        "threadId": thread_id,
+                        "turnId": turn_id,
+                        "tokenUsage": {
+                            "total": {
+                                "totalTokens": 7,
+                                "inputTokens": 3,
+                                "cachedInputTokens": 0,
+                                "outputTokens": 4,
+                                "reasoningOutputTokens": 0,
+                            }
+                        },
+                    },
+                }
+            )
+            send(
+                {
+                    "method": "turn/completed",
+                    "params": {"threadId": thread_id, "turn": {"id": turn_id, "items": [], "status": "interrupted", "error": None}},
+                }
+            )
+            return 0
+        elif message.get("id") == approval_request_id and "result" in message:
+            send({"method": "item/agentMessage/delta", "params": {"threadId": thread_id, "turnId": turn_id, "itemId": "msg_1", "delta": " approved"}})
+            send({"method": "turn/diff/updated", "params": {"threadId": thread_id, "turnId": turn_id, "diff": "diff --git a/README.md b/README.md"}})
+            send(
+                {
+                    "method": "item/completed",
+                    "params": {
+                        "threadId": thread_id,
+                        "turnId": turn_id,
+                        "item": {"type": "agentMessage", "id": "msg_1", "text": "Working approved", "phase": "final_answer"},
+                    },
+                }
+            )
+            send(
+                {
+                    "method": "thread/tokenUsage/updated",
+                    "params": {
+                        "threadId": thread_id,
+                        "turnId": turn_id,
+                        "tokenUsage": {
+                            "total": {
+                                "totalTokens": 9,
+                                "inputTokens": 4,
+                                "cachedInputTokens": 1,
+                                "outputTokens": 5,
+                                "reasoningOutputTokens": 0,
+                            }
+                        },
+                    },
+                }
+            )
+            send({"method": "thread/status/changed", "params": {"threadId": thread_id, "status": {"type": "idle"}}})
+            send(
+                {
+                    "method": "turn/completed",
+                    "params": {"threadId": thread_id, "turn": {"id": turn_id, "items": [], "status": "completed", "error": None}},
+                }
+            )
+            return 0
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+""",
+        encoding="utf-8",
+    )
+    target.chmod(0o755)
+    return target
+
+
+def _poll_run_status(temp_hive_dir: str, capsys, run_id: str, *, attempts: int = 20) -> dict:
+    payload: dict = {}
+    for _ in range(attempts):
+        payload = _invoke_cli_json(capsys, ["--path", temp_hive_dir, "--json", "run", "status", run_id])
+        if payload.get("status"):
+            return payload
+        time.sleep(0.1)
+    return payload
 
 
 class TestHiveDrivers:
@@ -795,6 +980,137 @@ class TestHiveDrivers:
             channel_path
         )
         assert "approval.forwarded" in event_types
+
+    def test_codex_app_server_launches_live_run_and_round_trips_approval(
+        self, temp_hive_dir, capsys, monkeypatch
+    ):
+        init_git_repo(temp_hive_dir)
+        _invoke_cli_json(
+            capsys,
+            ["--path", temp_hive_dir, "--json", "quickstart", "demo", "--title", "Demo"],
+        )
+        write_safe_program(temp_hive_dir, "demo")
+        subprocess.run(["git", "add", "-A"], cwd=temp_hive_dir, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Bootstrap workspace"],
+            cwd=temp_hive_dir,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        driver = get_driver("codex")
+        fake_binary = _write_fake_codex_binary(temp_hive_dir)
+
+        def fake_detected_binary_details(self):
+            return ("codex", str(fake_binary))
+
+        monkeypatch.setattr(type(driver), "_detected_binary_details", fake_detected_binary_details)
+        monkeypatch.setenv("HIVE_CODEX_LIVE_APP_SERVER", "1")
+        monkeypatch.delenv("HIVE_CODEX_LIVE_EXEC", raising=False)
+
+        task_id = ready_tasks(temp_hive_dir, project_id="demo")[0]["id"]
+        run = start_run(temp_hive_dir, task_id, driver_name="codex")
+
+        pending_payload = {}
+        for _ in range(30):
+            pending_payload = _invoke_cli_json(
+                capsys,
+                ["--path", temp_hive_dir, "--json", "run", "status", run.id],
+            )
+            if pending_payload["status"]["pending_approvals"]:
+                break
+            time.sleep(0.1)
+
+        approval_id = pending_payload["status"]["pending_approvals"][0]["approval_id"]
+        resolution = steer_run(
+            temp_hive_dir,
+            run.id,
+            SteeringRequest(action="approve", target={"approval_id": approval_id}),
+            actor="operator",
+        )
+
+        completed_payload = {}
+        for _ in range(30):
+            completed_payload = _invoke_cli_json(
+                capsys,
+                ["--path", temp_hive_dir, "--json", "run", "status", run.id],
+            )
+            if completed_payload["status"]["state"] == "completed_candidate":
+                break
+            time.sleep(0.1)
+
+        metadata = load_run(temp_hive_dir, run.id)
+        run_root = Path(temp_hive_dir) / ".hive" / "runs" / run.id
+        handles = json.loads((run_root / "driver" / "handles.json").read_text(encoding="utf-8"))
+        transcript = (run_root / "transcript.ndjson").read_text(encoding="utf-8")
+
+        assert resolution["driver_ack"]["ok"] is True
+        assert pending_payload["status"]["session"]["launch_mode"] == "app_server"
+        assert pending_payload["status"]["session"]["transport"] == "stdio-jsonrpc"
+        assert pending_payload["status"]["waiting_on"] == "approval"
+        assert pending_payload["status"]["pending_approvals"][0]["payload"]["command"] == "git status"
+        assert completed_payload["status"]["state"] == "completed_candidate"
+        assert completed_payload["status"]["session"]["thread_id"] == "thread_test"
+        assert handles["active"]["launch_mode"] == "app_server"
+        assert handles["active"]["thread_id"] == "thread_test"
+        assert metadata["metadata_json"]["budget_rollup"]["spent_tokens"] == 9
+        assert "Working" in transcript
+        assert "approved" in transcript
+
+    def test_codex_app_server_cancel_routes_interrupt_request(
+        self, temp_hive_dir, capsys, monkeypatch
+    ):
+        init_git_repo(temp_hive_dir)
+        _invoke_cli_json(
+            capsys,
+            ["--path", temp_hive_dir, "--json", "quickstart", "demo", "--title", "Demo"],
+        )
+        write_safe_program(temp_hive_dir, "demo")
+        subprocess.run(["git", "add", "-A"], cwd=temp_hive_dir, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Bootstrap workspace"],
+            cwd=temp_hive_dir,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        driver = get_driver("codex")
+        fake_binary = _write_fake_codex_binary(temp_hive_dir)
+
+        def fake_detected_binary_details(self):
+            return ("codex", str(fake_binary))
+
+        def fake_prompt(self, request):
+            return "WAIT_FOR_INTERRUPT"
+
+        monkeypatch.setattr(type(driver), "_detected_binary_details", fake_detected_binary_details)
+        monkeypatch.setattr(type(driver), "_build_exec_prompt", fake_prompt)
+        monkeypatch.setenv("HIVE_CODEX_LIVE_APP_SERVER", "1")
+        monkeypatch.delenv("HIVE_CODEX_LIVE_EXEC", raising=False)
+
+        task_id = ready_tasks(temp_hive_dir, project_id="demo")[0]["id"]
+        run = start_run(temp_hive_dir, task_id, driver_name="codex")
+
+        interrupt_payload = steer_run(
+            temp_hive_dir,
+            run.id,
+            SteeringRequest(action="cancel"),
+            actor="operator",
+        )
+
+        cancelled_payload = {}
+        for _ in range(30):
+            cancelled_payload = _invoke_cli_json(
+                capsys,
+                ["--path", temp_hive_dir, "--json", "run", "status", run.id],
+            )
+            if cancelled_payload["status"]["state"] == "cancelled":
+                break
+            time.sleep(0.1)
+
+        assert interrupt_payload["driver_ack"]["ok"] is True
+        assert cancelled_payload["status"]["state"] == "cancelled"
+        assert cancelled_payload["status"]["session"]["launch_mode"] == "app_server"
 
     def test_run_status_refreshes_live_claude_driver_status(
         self, temp_hive_dir, capsys, monkeypatch

--- a/tests/test_v23_runtime_foundation.py
+++ b/tests/test_v23_runtime_foundation.py
@@ -158,8 +158,37 @@ def test_driver_doctor_surfaces_claude_live_exec_when_enabled(monkeypatch, capsy
     assert driver_payload["driver"] == "claude-code"
     assert driver_payload["effective"]["launch_mode"] == "exec"
     assert driver_payload["effective"]["session_persistence"] == "ephemeral"
+
+
+def test_driver_doctor_surfaces_codex_app_server_when_enabled(monkeypatch, capsys, temp_hive_dir):
+    driver = get_driver("codex")
+
+    def fake_detected_binary_details(self):
+        return ("codex", "/tmp/codex")
+
+    def fake_command_output(self, *args):
+        if args == ("--help",):
+            return "Commands:\n  exec\n  app-server\n"
+        if args == ("app-server", "--help"):
+            return "Usage: codex app-server --listen <URL>\n  --listen <URL>\n"
+        if args == ("exec", "--help"):
+            return "Usage: codex exec --json\n"
+        if args in {("--version",), ("version",)}:
+            return "codex 0.0.0-test"
+        return ""
+
+    monkeypatch.setattr(type(driver), "_detected_binary_details", fake_detected_binary_details)
+    monkeypatch.setattr(type(driver), "_command_output", fake_command_output)
+    monkeypatch.setenv("HIVE_CODEX_LIVE_APP_SERVER", "1")
+    monkeypatch.delenv("HIVE_CODEX_LIVE_EXEC", raising=False)
+
+    payload = _invoke_cli_json(capsys, ["--path", temp_hive_dir, "--json", "driver", "doctor", "codex"])
+
+    driver_payload = payload["drivers"][0]
+    assert driver_payload["effective"]["launch_mode"] == "app_server"
+    assert driver_payload["effective"]["session_persistence"] == "thread"
     assert driver_payload["confidence"]["effective"] == "verified"
-    assert "non-interactive Claude run" in driver_payload["notes"][-1]
+    assert "live interactive Codex run" in driver_payload["notes"][-1]
 
 
 def test_live_session_contract_fields_round_trip():


### PR DESCRIPTION
## Summary
- add a real Codex app-server bridge worker that speaks newline-delimited stdio JSON-RPC
- launch Codex in `app_server` mode when `HIVE_CODEX_LIVE_APP_SERVER=1`, ingest transcript/plan/diff/token events, and round-trip approvals/interrupts through the existing Hive control channel
- cover the live path with driver/runtime tests, including approval continuation, cancellation, and driver doctor reporting

## Testing
- `uv run pytest tests/test_hive_drivers.py tests/test_v23_runtime_foundation.py -q`
- `make check`
