### PR TITLE
Fix Claude review workflow triggers

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,6 +1,9 @@
 name: Claude Code
 
 on:
+  # Review pull requests when they are opened, updated, reopened, or marked ready
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   # Respond to @claude mentions in issue comments
   issue_comment:
     types: [created]
@@ -16,7 +19,7 @@ on:
 
 jobs:
   claude-response:
-    # Only run if the event contains @claude or is assigned to claude
+    # Only run interactive mention and assignment flows on non-PR-lifecycle events.
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@Claude')) ||
@@ -41,16 +44,55 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Copy event payload for Claude normalization
+        run: cp "${GITHUB_EVENT_PATH}" "${RUNNER_TEMP}/claude-event.json"
+
       - name: Normalize Claude trigger casing
-        run: python .github/scripts/normalize_claude_trigger.py "${GITHUB_EVENT_PATH}"
+        run: python .github/scripts/normalize_claude_trigger.py "${RUNNER_TEMP}/claude-event.json"
 
       - name: Run Claude Code Action
         uses: anthropics/claude-code-action@v1
+        env:
+          GITHUB_EVENT_PATH: ${{ runner.temp }}/claude-event.json
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           trigger_phrase: "@claude"
-          # Use a sticky comment to consolidate Claude's responses
-          use_sticky_comment: true
           # Allowed tools for this repository
           claude_args: |
             --allowedTools "Bash(*),Read,Write,Edit,Glob,Grep,TodoWrite"
+
+  claude-review:
+    if: github.event_name == 'pull_request' && !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude PR review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Please review this pull request with a focus on:
+            - Bugs and behavioral regressions
+            - Missing tests or validation gaps
+            - Security or safety risks
+            - Mismatches between implementation and stated intent
+
+            Use `gh pr comment` for top-level feedback.
+            Use `mcp__github_inline_comment__create_inline_comment` with `confirmed: true` for code-specific findings.
+            Only post GitHub comments. Do not submit review text as plain action messages.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary
- add pull request lifecycle triggers so Claude can review PRs on open, update, reopen, and ready-for-review
- stop mutating the original GitHub event payload in place by normalizing a temp copy instead
- disable sticky mention comments in the mention-driven job to avoid repeated noisy log-dump comments

## Testing
- `uv run python - <<'PY' ... yaml.safe_load('.github/workflows/claude.yml') ... PY`
- `uv run python - <<'PY' ... normalize_claude_trigger.py temp-event.json ... PY`
