### PR TITLE
Make sandbox doctor config-aware

### DIFF
--- a/src/hive/sandbox/base.py
+++ b/src/hive/sandbox/base.py
@@ -13,8 +13,11 @@ class SandboxProbe:
     backend: str
     available: bool
     isolation_class: str
+    configured: bool | None = None
     supported_profiles: list[str] = field(default_factory=list)
     experimental: bool = False
+    blockers: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
     notes: list[str] = field(default_factory=list)
     evidence: dict[str, Any] = field(default_factory=dict)
 

--- a/src/hive/sandbox/registry.py
+++ b/src/hive/sandbox/registry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 import json
+import os
 from pathlib import Path
 import shutil
 import subprocess
@@ -60,6 +61,7 @@ class BinarySandboxBackend(SandboxBackend):
         binary = self._find_binary()
         notes = []
         evidence = {}
+        blockers = []
         if binary:
             notes.append(f"Detected backend binary at {binary}.")
             evidence["binary"] = binary
@@ -67,16 +69,69 @@ class BinarySandboxBackend(SandboxBackend):
             if version:
                 evidence["version"] = version
         else:
-            notes.append(self.note_when_missing)
+            blockers.append(self.note_when_missing)
         return SandboxProbe(
             backend=self.name,
             available=bool(binary),
             isolation_class=self.isolation_class,
+            configured=bool(binary),
             supported_profiles=list(self.supported_profiles),
             experimental=self.experimental,
+            blockers=blockers,
             notes=notes,
             evidence=evidence,
         )
+
+
+class CredentialAwareSandboxBackend(BinarySandboxBackend):
+    """Probe remote backends that need non-interactive auth or target config."""
+
+    auth_env_groups: tuple[tuple[str, ...], ...] = ()
+    required_env: tuple[str, ...] = ()
+    auth_warning = (
+        "Hive could not verify non-interactive credentials from environment variables; "
+        "interactive CLI login may still be configured."
+    )
+    required_env_note = ""
+
+    def probe(self) -> SandboxProbe:
+        probe = super().probe()
+        if not probe.available:
+            probe.configured = False
+            return probe
+        env_names = {
+            name
+            for group in self.auth_env_groups
+            for name in group
+        } | set(self.required_env)
+        env_state = {name: bool(os.getenv(name)) for name in sorted(env_names)}
+        if env_state:
+            probe.evidence["env"] = env_state
+        matched_group = next(
+            (
+                group
+                for group in self.auth_env_groups
+                if group and all(os.getenv(name) for name in group)
+            ),
+            None,
+        )
+        if matched_group:
+            probe.notes.append(
+                "Detected non-interactive configuration via "
+                + ", ".join(matched_group)
+                + "."
+            )
+            probe.evidence["auth_source"] = list(matched_group)
+        elif self.auth_env_groups:
+            probe.warnings.append(self.auth_warning)
+        missing_required = [name for name in self.required_env if not os.getenv(name)]
+        if missing_required:
+            note = self.required_env_note or (
+                "Missing required configuration: " + ", ".join(missing_required) + "."
+            )
+            probe.blockers.append(note)
+        probe.configured = matched_group is not None and not missing_required
+        return probe
 
 
 class PodmanBackend(BinarySandboxBackend):
@@ -102,6 +157,7 @@ class PodmanBackend(BinarySandboxBackend):
         probe.evidence["rootless"] = rootless
         if not rootless:
             probe.available = False
+            probe.configured = False
             probe.notes.append("Podman is installed but is not running rootless.")
         else:
             probe.notes.append("Podman rootless mode is available for local-safe sandboxing.")
@@ -126,6 +182,7 @@ class DockerRootlessBackend(BinarySandboxBackend):
             probe.notes.append("Docker daemon advertises rootless security mode.")
             return probe
         probe.available = False
+        probe.configured = False
         probe.notes.append("Docker CLI is present, but the daemon is not advertising rootless mode.")
         return probe
 
@@ -138,27 +195,47 @@ class AsrtBackend(BinarySandboxBackend):
     note_when_missing = "Anthropic Sandbox Runtime (`srt`) was not detected on PATH."
 
 
-class E2BBackend(BinarySandboxBackend):
+class E2BBackend(CredentialAwareSandboxBackend):
     name = "e2b"
     isolation_class = "managed-sandbox"
     binaries = ("e2b",)
     supported_profiles = ("hosted-managed",)
+    auth_env_groups = (("E2B_API_KEY",), ("E2B_ACCESS_TOKEN",))
+    auth_warning = (
+        "E2B CLI is present, but Hive did not detect `E2B_API_KEY` or `E2B_ACCESS_TOKEN`; "
+        "interactive `e2b auth login` may still work, but automation readiness is unverified."
+    )
 
 
-class DaytonaBackend(BinarySandboxBackend):
+class DaytonaBackend(CredentialAwareSandboxBackend):
     name = "daytona"
     isolation_class = "remote-sandbox"
     binaries = ("daytona",)
     supported_profiles = ("team-self-hosted",)
+    auth_env_groups = (("DAYTONA_API_KEY",), ("DAYTONA_JWT_TOKEN", "DAYTONA_ORGANIZATION_ID"))
+    required_env = ("DAYTONA_API_URL",)
+    auth_warning = (
+        "Daytona CLI is present, but Hive did not detect `DAYTONA_API_KEY` or the "
+        "`DAYTONA_JWT_TOKEN` + `DAYTONA_ORGANIZATION_ID` pair."
+    )
+    required_env_note = (
+        "Missing `DAYTONA_API_URL`, so Hive cannot verify a team-self-hosted Daytona "
+        "control plane target."
+    )
 
 
-class CloudflareBackend(BinarySandboxBackend):
+class CloudflareBackend(CredentialAwareSandboxBackend):
     name = "cloudflare"
     isolation_class = "remote-sandbox"
     binaries = ("wrangler",)
     experimental = True
     supported_profiles = ("experimental",)
     note_when_missing = "Wrangler was not detected on PATH for Cloudflare sandbox experiments."
+    auth_env_groups = (("CLOUDFLARE_API_TOKEN",), ("CLOUDFLARE_API_KEY", "CLOUDFLARE_EMAIL"))
+    auth_warning = (
+        "Wrangler is present, but Hive did not detect Cloudflare API credentials; "
+        "interactive `wrangler login` may still work, but automation readiness is unverified."
+    )
 
 
 _BACKENDS = {

--- a/tests/test_v23_runtime_foundation.py
+++ b/tests/test_v23_runtime_foundation.py
@@ -242,7 +242,84 @@ def test_sandbox_doctor_lists_scaffolded_backends(capsys, temp_hive_dir):
 
     assert backends == ["podman", "docker-rootless", "asrt", "e2b", "daytona", "cloudflare"]
     assert payload["backends"][0]["supported_profiles"] == ["local-safe"]
+    assert "configured" in payload["backends"][0]
     assert payload["backends"][-1]["experimental"] is True
+
+
+def test_e2b_probe_reports_auth_unverified_without_env(monkeypatch):
+    backend = get_backend("e2b")
+
+    def fake_find_binary(self):
+        return "/tmp/e2b"
+
+    def fake_command_output(self, *args):
+        if args == ("--version",):
+            return "e2b 0.1.0"
+        return None
+
+    monkeypatch.setattr(type(backend), "_find_binary", fake_find_binary)
+    monkeypatch.setattr(type(backend), "_command_output", fake_command_output)
+    monkeypatch.delenv("E2B_API_KEY", raising=False)
+    monkeypatch.delenv("E2B_ACCESS_TOKEN", raising=False)
+
+    probe = backend.probe()
+
+    assert probe.available is True
+    assert probe.configured is False
+    assert probe.warnings
+    assert probe.evidence["env"]["E2B_API_KEY"] is False
+    assert probe.evidence["env"]["E2B_ACCESS_TOKEN"] is False
+
+
+def test_daytona_probe_requires_api_url_for_self_hosted(monkeypatch):
+    backend = get_backend("daytona")
+
+    def fake_find_binary(self):
+        return "/tmp/daytona"
+
+    def fake_command_output(self, *args):
+        if args == ("--version",):
+            return "daytona 0.1.0"
+        return None
+
+    monkeypatch.setattr(type(backend), "_find_binary", fake_find_binary)
+    monkeypatch.setattr(type(backend), "_command_output", fake_command_output)
+    monkeypatch.setenv("DAYTONA_API_KEY", "token")
+    monkeypatch.delenv("DAYTONA_API_URL", raising=False)
+    monkeypatch.delenv("DAYTONA_JWT_TOKEN", raising=False)
+    monkeypatch.delenv("DAYTONA_ORGANIZATION_ID", raising=False)
+
+    probe = backend.probe()
+
+    assert probe.available is True
+    assert probe.configured is False
+    assert "DAYTONA_API_KEY" in probe.evidence["auth_source"]
+    assert any("DAYTONA_API_URL" in blocker for blocker in probe.blockers)
+
+
+def test_cloudflare_probe_detects_api_token_configuration(monkeypatch):
+    backend = get_backend("cloudflare")
+
+    def fake_find_binary(self):
+        return "/tmp/wrangler"
+
+    def fake_command_output(self, *args):
+        if args == ("--version",):
+            return "wrangler 0.1.0"
+        return None
+
+    monkeypatch.setattr(type(backend), "_find_binary", fake_find_binary)
+    monkeypatch.setattr(type(backend), "_command_output", fake_command_output)
+    monkeypatch.setenv("CLOUDFLARE_API_TOKEN", "token")
+    monkeypatch.delenv("CLOUDFLARE_API_KEY", raising=False)
+    monkeypatch.delenv("CLOUDFLARE_EMAIL", raising=False)
+
+    probe = backend.probe()
+
+    assert probe.available is True
+    assert probe.configured is True
+    assert probe.experimental is True
+    assert probe.evidence["auth_source"] == ["CLOUDFLARE_API_TOKEN"]
 
 
 def test_start_run_writes_v23_foundation_artifacts(temp_hive_dir, capsys):


### PR DESCRIPTION
## Summary
- add `configured`, `warnings`, and `blockers` to sandbox doctor probes so remote backends can report install state separately from automation readiness
- make `e2b`, `daytona`, and experimental `cloudflare` probes detect credential/config environment variables instead of overclaiming readiness from binary presence alone
- keep local backends truthful by marking non-rootless Podman/Docker as not configured

## Testing
- make check
- uv run pytest tests/test_v23_runtime_foundation.py -q
- uv run pytest tests/test_cli_schema_fixtures.py tests/test_console_api.py -q