### PR TITLE
Guard Claude workflow comments against log dumps

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -57,6 +57,16 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           trigger_phrase: "@claude"
+          prompt: |
+            REPO: ${{ github.repository }}
+            EVENT NAME: ${{ github.event_name }}
+
+            Respond to the GitHub mention or assignment request directly on GitHub.
+            Keep GitHub comments concise and actionable.
+            Never paste raw shell output, test logs, or long diffs into a GitHub comment.
+            Summarize command results in prose and point to the workflow or job URL for full logs.
+            Quote only the minimum relevant evidence needed to support a conclusion.
+            Only publish the final GitHub comment or PR update, not raw action output.
           # Allowed tools for this repository
           claude_args: |
             --allowedTools "Bash(*),Read,Write,Edit,Glob,Grep,TodoWrite"
@@ -91,6 +101,10 @@ jobs:
             - Security or safety risks
             - Mismatches between implementation and stated intent
 
+            Keep GitHub comments concise and actionable.
+            Never paste raw shell output, test logs, or long diffs into a GitHub comment.
+            Summarize command results in prose and point to the workflow or job URL for full logs.
+            Quote only the minimum relevant evidence needed to support a conclusion.
             Use `gh pr comment` for top-level feedback.
             Use `mcp__github_inline_comment__create_inline_comment` with `confirmed: true` for code-specific findings.
             Only post GitHub comments. Do not submit review text as plain action messages.

--- a/tests/test_claude_workflow.py
+++ b/tests/test_claude_workflow.py
@@ -1,0 +1,22 @@
+"""Workflow guardrails for Claude GitHub automation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+def test_claude_workflows_discourage_raw_log_dump_comments():
+    """Both Claude workflows should summarize logs instead of pasting them into comments."""
+    workflow_path = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "claude.yml"
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    response_prompt = workflow["jobs"]["claude-response"]["steps"][-1]["with"]["prompt"]
+    review_prompt = workflow["jobs"]["claude-review"]["steps"][-1]["with"]["prompt"]
+
+    for prompt in (response_prompt, review_prompt):
+        assert "Keep GitHub comments concise and actionable." in prompt
+        assert "Never paste raw shell output, test logs, or long diffs" in prompt
+        assert "Summarize command results in prose" in prompt
+        assert "workflow or job URL for full logs" in prompt
+    assert "Only publish the final GitHub comment or PR update" in response_prompt


### PR DESCRIPTION
## Summary
- add explicit no-log-dump guardrails to the interactive `claude-response` workflow prompt
- mirror the same guardrails into `claude-review` so PR comments stay concise there too
- add a workflow regression test that locks in the prompt contract for both jobs

## Testing
- uv run pytest tests/test_claude_workflow.py tests/test_claude_trigger_normalizer.py -q
- make check