### PR TITLE
Import Claude live exec output into runtime artifacts

### DIFF
--- a/src/hive/runs/driver_state.py
+++ b/src/hive/runs/driver_state.py
@@ -158,6 +158,19 @@ def _normalize_codex_event(record: dict[str, Any]) -> tuple[str | None, dict[str
     return event_type, dict(payload), ts
 
 
+def _load_json_record(path: Path) -> dict[str, Any] | None:
+    lines = [line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    if not lines:
+        return None
+    try:
+        payload = json.loads(lines[-1])
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
 def _record_driver_usage(metadata: dict, status_payload: dict[str, object], usage: dict[str, Any]) -> None:
     input_tokens = int(
         usage.get("input_tokens", 0)
@@ -535,6 +548,83 @@ def _thread_token_usage_payload(payload: dict[str, Any]) -> dict[str, Any] | Non
     }
 
 
+def _ingest_claude_exec_output(
+    root: Path,
+    metadata: dict,
+    handle: RunHandle,
+    status_payload: dict[str, object],
+) -> None:
+    if str(metadata.get("driver")) != "claude-code" or handle.launch_mode != "exec":
+        return
+    artifacts = status_payload.get("artifacts")
+    if not isinstance(artifacts, dict):
+        return
+    raw_output_path = artifacts.get("raw_output_path") or handle.metadata.get("raw_output_path")
+    if not isinstance(raw_output_path, str) or not raw_output_path.strip():
+        return
+    raw_path = Path(raw_output_path)
+    if not raw_path.exists():
+        return
+    payload = _load_json_record(raw_path)
+    if payload is None:
+        return
+
+    imports = _driver_imports(metadata)
+    usage = dict(payload.get("usage") or {})
+    if usage:
+        usage["cost_usd"] = float(payload.get("total_cost_usd") or usage.get("cost_usd") or 0.0)
+        _record_driver_usage(metadata, status_payload, usage)
+
+    payload_digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True).encode("utf-8")
+    ).hexdigest()
+    if imports.get("claude_exec_result_sha256") == payload_digest:
+        imports["claude_exec_raw_output_path"] = str(raw_path)
+        return
+
+    source = "driver.claude.exec"
+    result_text = str(payload.get("result") or "").strip()
+    if result_text:
+        _append_transcript_entry(
+            Path(metadata["transcript_path"]),
+            {
+                "ts": utc_now_iso(),
+                "kind": "assistant",
+                "driver": metadata.get("driver"),
+                "message": result_text,
+                "driver_event_type": "claude.print_result",
+                "state": status_payload.get("state"),
+            },
+        )
+        _emit_runtime_driver_event(
+            root,
+            metadata,
+            event_type="driver.output.delta",
+            source=source,
+            payload={"driver_event_type": "claude.print_result", "message": result_text},
+        )
+        imports["last_message_sha256"] = hashlib.sha256(
+            result_text.encode("utf-8")
+        ).hexdigest()
+
+    _emit_runtime_driver_event(
+        root,
+        metadata,
+        event_type="driver.status",
+        source=source,
+        payload={
+            "driver_event_type": "claude.print_result",
+            "payload": {
+                "session_id": payload.get("session_id"),
+                "total_cost_usd": payload.get("total_cost_usd"),
+                "duration_ms": payload.get("duration_ms"),
+            },
+        },
+    )
+    imports["claude_exec_result_sha256"] = payload_digest
+    imports["claude_exec_raw_output_path"] = str(raw_path)
+
+
 def _ingest_codex_app_server_events(
     root: Path,
     metadata: dict,
@@ -739,6 +829,7 @@ def _refresh_live_driver_status(root: Path, metadata: dict) -> dict[str, object]
     status = driver.status(handle)
     status_payload = status.to_dict()
     _ingest_codex_exec_events(root, metadata, handle, status_payload)
+    _ingest_claude_exec_output(root, metadata, handle, status_payload)
     _ingest_codex_app_server_events(root, metadata, handle, status_payload)
     _sync_run_budget_from_status(metadata, status_payload)
     _record_driver_status(metadata, status_payload)

--- a/tests/test_v23_runtime_foundation.py
+++ b/tests/test_v23_runtime_foundation.py
@@ -1367,6 +1367,111 @@ def test_run_status_imports_live_codex_events_into_runtime_artifacts(
     assert "approval.requested" in event_types
 
 
+def test_run_status_imports_live_claude_output_into_runtime_artifacts(
+    temp_hive_dir, capsys, monkeypatch
+):
+    _bootstrap_workspace(temp_hive_dir, capsys)
+    driver = get_driver("claude-code")
+
+    def fake_live_exec_enabled(self):
+        return True
+
+    def fake_launch_live_exec(self, request):
+        raw_output_path = (
+            Path(request.artifacts_path) / "transcript" / "raw" / "claude-print-result.json"
+        )
+        raw_output_path.parent.mkdir(parents=True, exist_ok=True)
+        raw_output_path.write_text(
+            json.dumps(
+                {
+                    "session_id": "sess-7200",
+                    "total_cost_usd": 0.45,
+                    "duration_ms": 90_000,
+                    "usage": {
+                        "input_tokens": 100,
+                        "cache_creation_input_tokens": 0,
+                        "cache_read_input_tokens": 0,
+                        "output_tokens": 23,
+                    },
+                    "result": "Delivered the requested implementation.",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return RunHandle(
+            run_id=request.run_id,
+            driver="claude-code",
+            driver_handle=f"claude-code:exec:{request.run_id}",
+            status="running",
+            launched_at="2026-03-18T06:00:00Z",
+            launch_mode="exec",
+            transport="subprocess",
+            session_id="sess-7200",
+            event_cursor="0",
+            metadata={"pid": 7200, "raw_output_path": str(raw_output_path)},
+        )
+
+    def fake_status(self, handle):
+        raw_output_path = str(handle.metadata["raw_output_path"])
+        return RunStatus(
+            run_id=handle.run_id,
+            state="completed_candidate",
+            health="healthy",
+            driver="claude-code",
+            progress=RunProgress(
+                phase="completed",
+                message="Claude live exec finished.",
+                percent=100,
+            ),
+            waiting_on="review",
+            last_event_at="2026-03-18T06:04:00Z",
+            event_cursor="1",
+            session={
+                "launch_mode": "exec",
+                "transport": "subprocess",
+                "session_id": "sess-7200",
+            },
+            artifacts={"raw_output_path": raw_output_path},
+        )
+
+    monkeypatch.setattr(type(driver), "_live_exec_enabled", fake_live_exec_enabled)
+    monkeypatch.setattr(type(driver), "_launch_live_exec", fake_launch_live_exec)
+    monkeypatch.setattr(type(driver), "status", fake_status)
+
+    task_id = ready_tasks(temp_hive_dir, project_id="demo")[0]["id"]
+    run = start_run(temp_hive_dir, task_id, driver_name="claude-code")
+    first_payload = _invoke_cli_json(
+        capsys,
+        ["--path", temp_hive_dir, "--json", "run", "status", run.id],
+    )
+    second_payload = _invoke_cli_json(
+        capsys,
+        ["--path", temp_hive_dir, "--json", "run", "status", run.id],
+    )
+    metadata = load_run(temp_hive_dir, run.id)
+    run_root = Path(temp_hive_dir) / ".hive" / "runs" / run.id
+    transcript = (run_root / "transcript.ndjson").read_text(encoding="utf-8")
+    event_types = [
+        json.loads(line)["type"]
+        for line in (run_root / "events.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+    assert first_payload["status"]["state"] == "completed_candidate"
+    assert second_payload["status"]["budget"]["spent_tokens"] == 123
+    assert metadata["metadata_json"]["driver_usage"]["spent_tokens"] == 123
+    assert metadata["tokens_in"] == 100
+    assert metadata["tokens_out"] == 23
+    assert metadata["cost_usd"] == 0.45
+    assert metadata["metadata_json"]["driver_imports"]["claude_exec_raw_output_path"].endswith(
+        "claude-print-result.json"
+    )
+    assert transcript.count("Delivered the requested implementation.") == 1
+    assert "driver.output.delta" in event_types
+    assert "driver.status" in event_types
+
+
 def test_eval_run_refreshes_live_codex_state_before_review(temp_hive_dir, capsys, monkeypatch):
     _bootstrap_workspace(temp_hive_dir, capsys)
     driver = get_driver("codex")


### PR DESCRIPTION
## Summary
- normalize Claude live exec result JSON into transcript/runtime events during status refresh
- keep budget usage synced on repeated refreshes while deduping transcript/event imports
- add v2.3 runtime coverage for Claude live output import and dedupe behavior

## Testing
- uv run pytest tests/test_v23_runtime_foundation.py -q -k "run_status_imports_live_claude_output_into_runtime_artifacts or run_status_refresh_surfaces_live_claude_session_payload or eval_run_refreshes_live_claude_state_before_review"
- uv run pytest tests/test_hive_drivers.py -q -k claude
- make check