### PR TITLE
Wire hosted-managed E2B sandbox execution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ dashboard = [
     "fastapi>=0.115.0,<1.0.0",
     "uvicorn>=0.32.0,<1.0.0",
 ]
+sandbox-e2b = [
+    "e2b>=2.2.5,<3.0.0",
+]
 console = [
     "fastapi>=0.115.0,<1.0.0",
     "uvicorn>=0.32.0,<1.0.0",

--- a/src/hive/runs/executors.py
+++ b/src/hive/runs/executors.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import io
 import json
+import os
 from pathlib import Path
 import subprocess
+import tarfile
 from typing import Protocol
 
 from src.hive.clock import utc_now_iso
@@ -44,6 +47,14 @@ class LocalExecutor:
 
     def run_command(self, command: str, *, cwd: Path, timeout_seconds: int) -> CommandResult:
         started_at = utc_now_iso()
+        if self.sandbox_policy is not None and self.sandbox_policy.backend == "e2b":
+            return _run_e2b_command(
+                self.sandbox_policy,
+                command=command,
+                cwd=cwd,
+                timeout_seconds=timeout_seconds,
+                started_at=started_at,
+            )
         try:
             argv, use_shell = self._command_payload(command, cwd=cwd)
             sandbox = self._sandbox_metadata(command, argv=argv, use_shell=use_shell, cwd=cwd)
@@ -130,6 +141,229 @@ class LocalExecutor:
             "shell": use_shell,
             "cwd": str(cwd) if cwd else None,
         }
+
+
+_E2B_REMOTE_WORKTREE = "/workspace"
+_E2B_REMOTE_ARTIFACTS = "/artifacts"
+_E2B_REMOTE_ARCHIVE = "/tmp/hive-mounts.tar.gz"
+_E2B_DENY_ALL = "0.0.0.0/0"
+
+
+def _e2b_mount_roots(policy: SandboxPolicy, cwd: Path) -> tuple[Path, Path]:
+    mounts = list(policy.mounts.get("read_write") or [])
+    host_worktree = Path(str(mounts[0] if mounts else cwd)).resolve()
+    host_artifacts = Path(str(mounts[1] if len(mounts) > 1 else cwd)).resolve()
+    return host_worktree, host_artifacts
+
+
+def _archive_mounts(host_worktree: Path, host_artifacts: Path) -> bytes:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as archive:
+        archive.add(host_worktree, arcname="workspace")
+        if host_artifacts != host_worktree:
+            archive.add(host_artifacts, arcname="artifacts")
+    return buffer.getvalue()
+
+
+def _load_e2b_sdk():
+    """Import the optional E2B SDK only when the hosted executor is selected."""
+    try:
+        from e2b import Sandbox  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - exercised through monkeypatching
+        raise ImportError(
+            "E2B SDK is not installed. Install `mellona-hive[sandbox-e2b]` "
+            "or `pip install e2b` to use the hosted-managed executor."
+        ) from exc
+    return Sandbox
+
+
+def _e2b_env(policy: SandboxPolicy) -> dict[str, str]:
+    env: dict[str, str] = {}
+    if bool(policy.env.get("inherit")):
+        return dict(os.environ)
+    allowed_names = list(policy.env.get("allowlist") or []) + list(
+        policy.env.get("passthrough") or []
+    )
+    for env_name in allowed_names:
+        value = os.environ.get(str(env_name))
+        if value is not None:
+            env[str(env_name)] = value
+    return env
+
+
+def _stringify_output(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return str(value)
+
+
+def _coerce_remote_returncode(result: object) -> int:
+    for key in ("exit_code", "returncode"):
+        value = getattr(result, key, None)
+        if value is None and isinstance(result, dict):
+            value = result.get(key)
+        if value is not None:
+            return int(value)
+    return 0
+
+
+def _run_e2b_command(
+    policy: SandboxPolicy,
+    *,
+    command: str,
+    cwd: Path,
+    timeout_seconds: int,
+    started_at: str,
+) -> CommandResult:
+    """Run one evaluator-style command inside an ephemeral E2B sandbox."""
+    started = started_at
+    host_worktree, host_artifacts = _e2b_mount_roots(policy, cwd)
+    allowlist = [
+        str(item) for item in list(policy.network.get("allowlist") or []) if str(item).strip()
+    ]
+    if allowlist:
+        return CommandResult(
+            command=command,
+            started_at=started,
+            finished_at=utc_now_iso(),
+            returncode=1,
+            stdout="",
+            stderr=(
+                "E2B hosted-managed execution currently supports deny-all or inherited network "
+                "policies only; allowlists are not wired yet."
+            ),
+            timed_out=False,
+            sandbox={
+                "backend": policy.backend,
+                "profile": policy.profile,
+                "provenance": policy.provenance,
+                "network_mode": policy.network.get("mode"),
+                "network_allowlist": allowlist,
+                "command": command,
+                "command_payload": {"transport": "e2b-sdk"},
+                "shell": False,
+                "cwd": str(cwd),
+                "workspace_sync": "upload_only",
+            },
+        )
+    try:
+        relative_cwd = cwd.resolve().relative_to(host_worktree)
+    except ValueError:
+        relative_cwd = Path(".")
+    remote_cwd = str((Path(_E2B_REMOTE_WORKTREE) / relative_cwd).as_posix())
+    sandbox_metadata: dict[str, object] = {
+        "backend": policy.backend,
+        "profile": policy.profile,
+        "provenance": policy.provenance,
+        "network_mode": policy.network.get("mode"),
+        "network_allowlist": allowlist,
+        "command": command,
+        "command_payload": {
+            "transport": "e2b-sdk",
+            "remote_cwd": remote_cwd,
+        },
+        "shell": False,
+        "cwd": str(cwd),
+        "workspace_sync": "upload_only",
+        "remote_worktree": _E2B_REMOTE_WORKTREE,
+        "remote_artifacts": _E2B_REMOTE_ARTIFACTS,
+    }
+    sandbox = None
+    try:
+        if any(
+            policy.resources.get(key) is not None for key in ("cpu", "memory_mb", "disk_mb")
+        ):
+            raise NotImplementedError(
+                "E2B hosted-managed execution does not yet project explicit CPU, "
+                "memory, or disk limits."
+            )
+        if list(policy.mounts.get("read_only") or []):
+            raise NotImplementedError(
+                "E2B hosted-managed execution does not yet project extra read-only mounts."
+            )
+        sandbox_class = _load_e2b_sdk()
+        create_kwargs = {
+            "timeout": max(int(timeout_seconds) + 60, 300),
+            "metadata": {
+                "hive_backend": policy.backend,
+                "hive_profile": policy.profile,
+                "hive_cwd": str(cwd),
+            },
+            "allow_internet_access": policy.network.get("mode") != "deny",
+        }
+        sandbox = sandbox_class.create(**create_kwargs)
+        sandbox_metadata["remote_sandbox_id"] = getattr(sandbox, "sandbox_id", None)
+        archive_bytes = _archive_mounts(host_worktree, host_artifacts)
+        sandbox.files.make_dir(_E2B_REMOTE_WORKTREE)
+        sandbox.files.make_dir(_E2B_REMOTE_ARTIFACTS)
+        sandbox.files.write(_E2B_REMOTE_ARCHIVE, archive_bytes)
+        sandbox.commands.run(
+            (
+                f"mkdir -p {_E2B_REMOTE_WORKTREE} {_E2B_REMOTE_ARTIFACTS} && "
+                f"tar -xzf {_E2B_REMOTE_ARCHIVE} -C / && rm -f {_E2B_REMOTE_ARCHIVE}"
+            ),
+            cwd="/",
+            timeout=max(timeout_seconds, 60),
+        )
+        result = sandbox.commands.run(
+            command,
+            cwd=remote_cwd,
+            envs=_e2b_env(policy) or None,
+            timeout=timeout_seconds,
+        )
+        return CommandResult(
+            command=command,
+            started_at=started,
+            finished_at=utc_now_iso(),
+            returncode=_coerce_remote_returncode(result),
+            stdout=_stringify_output(getattr(result, "stdout", "")),
+            stderr=_stringify_output(getattr(result, "stderr", "")),
+            timed_out=False,
+            sandbox=sandbox_metadata,
+        )
+    except Exception as exc:  # pylint: disable=broad-except
+        if exc.__class__.__name__ == "TimeoutException":
+            return CommandResult(
+                command=command,
+                started_at=started,
+                finished_at=utc_now_iso(),
+                returncode=None,
+                stdout=_stringify_output(getattr(exc, "stdout", "")),
+                stderr=_stringify_output(getattr(exc, "stderr", str(exc))),
+                timed_out=True,
+                sandbox=sandbox_metadata,
+            )
+        if exc.__class__.__name__ == "CommandExitException" or getattr(
+            exc, "exit_code", None
+        ) is not None:
+            return CommandResult(
+                command=command,
+                started_at=started,
+                finished_at=utc_now_iso(),
+                returncode=int(getattr(exc, "exit_code", 1) or 1),
+                stdout=_stringify_output(getattr(exc, "stdout", "")),
+                stderr=_stringify_output(getattr(exc, "stderr", str(exc))),
+                timed_out=False,
+                sandbox=sandbox_metadata,
+            )
+        return CommandResult(
+            command=command,
+            started_at=started,
+            finished_at=utc_now_iso(),
+            returncode=1,
+            stdout="",
+            stderr=str(exc),
+            timed_out=False,
+            sandbox=sandbox_metadata,
+        )
+    finally:
+        if sandbox is not None:
+            try:
+                sandbox.kill()
+            except Exception:  # pragma: no cover - defensive cleanup
+                pass
 
 
 class GitHubActionsExecutor:

--- a/src/hive/sandbox/registry.py
+++ b/src/hive/sandbox/registry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+import importlib.util
 import json
 import os
 from pathlib import Path
@@ -183,7 +184,9 @@ class DockerRootlessBackend(BinarySandboxBackend):
             return probe
         probe.available = False
         probe.configured = False
-        probe.notes.append("Docker CLI is present, but the daemon is not advertising rootless mode.")
+        probe.notes.append(
+            "Docker CLI is present, but the daemon is not advertising rootless mode."
+        )
         return probe
 
 
@@ -205,6 +208,57 @@ class E2BBackend(CredentialAwareSandboxBackend):
         "E2B CLI is present, but Hive did not detect `E2B_API_KEY` or `E2B_ACCESS_TOKEN`; "
         "interactive `e2b auth login` may still work, but automation readiness is unverified."
     )
+
+    @staticmethod
+    def _sdk_available() -> bool:
+        return importlib.util.find_spec("e2b") is not None
+
+    def probe(self) -> SandboxProbe:
+        probe = super().probe()
+        has_sdk = self._sdk_available()
+        probe.evidence["python_sdk"] = has_sdk
+        env_names = {
+            name
+            for group in self.auth_env_groups
+            for name in group
+        }
+        matched_group = next(
+            (
+                group
+                for group in self.auth_env_groups
+                if group and all(os.getenv(name) for name in group)
+            ),
+            None,
+        )
+        if env_names:
+            probe.evidence["env"] = {name: bool(os.getenv(name)) for name in sorted(env_names)}
+        if has_sdk:
+            probe.notes.append("Detected Python E2B SDK for hosted-managed execution.")
+            if not probe.available:
+                probe.available = True
+                probe.notes.append("Python E2B SDK is available even though the CLI is missing.")
+                probe.blockers = [
+                    blocker for blocker in probe.blockers if blocker != self.note_when_missing
+                ]
+            if matched_group:
+                probe.evidence["auth_source"] = list(matched_group)
+                if not any(
+                    "Detected non-interactive configuration via" in note for note in probe.notes
+                ):
+                    probe.notes.append(
+                        "Detected non-interactive configuration via "
+                        + ", ".join(matched_group)
+                        + "."
+                    )
+            elif self.auth_env_groups and self.auth_warning not in probe.warnings:
+                probe.warnings.append(self.auth_warning)
+        else:
+            probe.blockers.append(
+                "Install `mellona-hive[sandbox-e2b]` or `pip install e2b` "
+                "for hosted-managed execution."
+            )
+        probe.configured = bool(matched_group and has_sdk)
+        return probe
 
 
 class DaytonaBackend(CredentialAwareSandboxBackend):

--- a/src/hive/sandbox/runtime.py
+++ b/src/hive/sandbox/runtime.py
@@ -20,12 +20,35 @@ _PROFILE_BACKENDS = {
     "team-self-hosted": ("daytona",),
     "experimental": ("cloudflare",),
 }
+_WIRED_BACKENDS = {"podman", "docker-rootless", "asrt", "e2b"}
 
 
-def _sandbox_profile_unavailable(profile: str, backend_names: tuple[str, ...]) -> ValueError:
+def _backend_readiness_reason(backend_name: str, probe) -> str:
+    details: list[str] = []
+    blockers = [str(item) for item in list(probe.blockers or []) if str(item).strip()]
+    warnings = [str(item) for item in list(probe.warnings or []) if str(item).strip()]
+    if blockers:
+        details.append("; ".join(blockers))
+    if warnings:
+        details.append("; ".join(warnings))
+    if backend_name not in _WIRED_BACKENDS:
+        details.append("executor wiring has not landed yet")
+    return f"{backend_name}: " + "; ".join(details) if details else backend_name
+
+
+def _sandbox_profile_unavailable(
+    profile: str,
+    backend_names: tuple[str, ...],
+    *,
+    details: list[str] | None = None,
+) -> ValueError:
     supported = ", ".join(backend_names)
+    suffix = ""
+    if details:
+        suffix = " " + " ".join(details)
     return ValueError(
         f"Sandbox profile {profile!r} requires one of [{supported}], but none were detected."
+        + suffix
     )
 
 
@@ -106,9 +129,13 @@ def resolve_sandbox_policy(
             profile=normalized,
         )
     probes = {probe.backend: probe for probe in iter_backend_probes(backend_names)}
+    readiness_failures: list[str] = []
     for backend_name in backend_names:
         probe = probes.get(backend_name)
         if probe is None or not probe.available:
+            continue
+        if probe.configured is False or backend_name not in _WIRED_BACKENDS:
+            readiness_failures.append(_backend_readiness_reason(backend_name, probe))
             continue
         return SandboxPolicy(
             backend=backend_name,
@@ -132,7 +159,7 @@ def resolve_sandbox_policy(
             profile=normalized,
             provenance=f"sandbox_v2_backend:{backend_name}",
         )
-    raise _sandbox_profile_unavailable(normalized, backend_names)
+    raise _sandbox_profile_unavailable(normalized, backend_names, details=readiness_failures)
 
 
 def sandboxed_command(

--- a/tests/test_v23_runtime_foundation.py
+++ b/tests/test_v23_runtime_foundation.py
@@ -24,6 +24,7 @@ from src.hive.runs.engine import accept_run, eval_run, load_run, run_artifacts, 
 from src.hive.scheduler.query import ready_tasks
 from src.hive.sandbox import get_backend
 from src.hive.sandbox.base import SandboxProbe
+from src.hive.sandbox.runtime import resolve_sandbox_policy
 from src.hive.store.task_files import create_task
 from tests.conftest import init_git_repo, write_safe_program
 
@@ -259,6 +260,7 @@ def test_e2b_probe_reports_auth_unverified_without_env(monkeypatch):
 
     monkeypatch.setattr(type(backend), "_find_binary", fake_find_binary)
     monkeypatch.setattr(type(backend), "_command_output", fake_command_output)
+    monkeypatch.setattr(type(backend), "_sdk_available", staticmethod(lambda: True))
     monkeypatch.delenv("E2B_API_KEY", raising=False)
     monkeypatch.delenv("E2B_ACCESS_TOKEN", raising=False)
 
@@ -269,6 +271,31 @@ def test_e2b_probe_reports_auth_unverified_without_env(monkeypatch):
     assert probe.warnings
     assert probe.evidence["env"]["E2B_API_KEY"] is False
     assert probe.evidence["env"]["E2B_ACCESS_TOKEN"] is False
+
+
+def test_e2b_probe_requires_python_sdk_for_hosted_execution(monkeypatch):
+    backend = get_backend("e2b")
+
+    def fake_find_binary(self):
+        return "/tmp/e2b"
+
+    def fake_command_output(self, *args):
+        if args == ("--version",):
+            return "e2b 0.1.0"
+        return None
+
+    monkeypatch.setattr(type(backend), "_find_binary", fake_find_binary)
+    monkeypatch.setattr(type(backend), "_command_output", fake_command_output)
+    monkeypatch.setattr(type(backend), "_sdk_available", staticmethod(lambda: False))
+    monkeypatch.setenv("E2B_API_KEY", "token")
+    monkeypatch.delenv("E2B_ACCESS_TOKEN", raising=False)
+
+    probe = backend.probe()
+
+    assert probe.available is True
+    assert probe.configured is False
+    assert probe.evidence["python_sdk"] is False
+    assert any("sandbox-e2b" in blocker for blocker in probe.blockers)
 
 
 def test_daytona_probe_requires_api_url_for_self_hosted(monkeypatch):
@@ -622,11 +649,116 @@ def test_local_executor_wraps_commands_for_asrt_local_fast(monkeypatch, tmp_path
     assert settings["network"]["allowedDomains"] == []
 
 
-def test_local_executor_reports_unwired_backend_as_failed_command(tmp_path):
+def test_local_executor_reports_unwired_daytona_backend_as_failed_command(tmp_path):
     worktree = tmp_path / "worktree"
     artifacts = tmp_path / "artifacts"
     worktree.mkdir()
     artifacts.mkdir()
+    executor = LocalExecutor(
+        SandboxPolicy(
+            backend="daytona",
+            isolation_class="remote-sandbox",
+            network={"mode": "deny", "allowlist": []},
+            mounts={
+                "read_only": [],
+                "read_write": [str(worktree), str(artifacts)],
+                "container_worktree": "/workspace",
+                "container_artifacts": "/artifacts",
+            },
+            resources={"cpu": None, "memory_mb": None, "disk_mb": None, "wall_clock_sec": None},
+            env={"inherit": False, "allowlist": ["LANG"], "passthrough": []},
+            snapshot=False,
+            resume=False,
+            profile="team-self-hosted",
+            provenance="sandbox_v2_backend:daytona",
+        )
+    )
+
+    result = executor.run_command("python -c \"print('ok')\"", cwd=worktree, timeout_seconds=30)
+
+    assert result.returncode == 1
+    assert result.timed_out is False
+    assert "not wired into the local executor yet" in result.stderr
+
+
+def test_resolve_hosted_managed_requires_configured_backend(monkeypatch, tmp_path):
+    backend = get_backend("e2b")
+    worktree = tmp_path / "worktree"
+    artifacts = tmp_path / "artifacts"
+    worktree.mkdir()
+    artifacts.mkdir()
+
+    def fake_probe(self):
+        return SandboxProbe(
+            backend="e2b",
+            available=True,
+            configured=False,
+            isolation_class="managed-sandbox",
+            supported_profiles=["hosted-managed"],
+            blockers=["Missing E2B_API_KEY"],
+            warnings=["CLI login is not enough for automation"],
+            notes=[],
+            evidence={},
+        )
+
+    monkeypatch.setattr(type(backend), "probe", fake_probe)
+
+    with pytest.raises(ValueError) as excinfo:
+        resolve_sandbox_policy(
+            worktree_path=str(worktree),
+            artifacts_path=str(artifacts),
+            profile="hosted-managed",
+        )
+
+    assert "e2b:" in str(excinfo.value)
+    assert "Missing E2B_API_KEY" in str(excinfo.value)
+
+
+def test_local_executor_runs_commands_via_e2b_sdk(monkeypatch, tmp_path):
+    worktree = tmp_path / "worktree"
+    artifacts = tmp_path / "artifacts"
+    worktree.mkdir()
+    artifacts.mkdir()
+    (worktree / "README.md").write_text("hello\n", encoding="utf-8")
+    calls: dict[str, object] = {}
+
+    class FakeCommandResult:
+        exit_code = 0
+        stdout = "ok\n"
+        stderr = ""
+
+    class FakeCommands:
+        def run(self, cmd, **kwargs):
+            calls.setdefault("commands", []).append({"cmd": cmd, "kwargs": kwargs})
+            return FakeCommandResult()
+
+    class FakeFiles:
+        def make_dir(self, path):
+            calls.setdefault("dirs", []).append(path)
+            return True
+
+        def write(self, path, data):
+            calls["write"] = {"path": path, "size": len(data)}
+            return {"path": path}
+
+    class FakeSandbox:
+        sandbox_id = "sbx_123"
+
+        def __init__(self):
+            self.files = FakeFiles()
+            self.commands = FakeCommands()
+
+        def kill(self):
+            calls["killed"] = True
+            return True
+
+        @classmethod
+        def create(cls, **kwargs):
+            calls["create"] = kwargs
+            return cls()
+
+    monkeypatch.setattr("src.hive.runs.executors._load_e2b_sdk", lambda: FakeSandbox)
+
     executor = LocalExecutor(
         SandboxPolicy(
             backend="e2b",
@@ -647,11 +779,60 @@ def test_local_executor_reports_unwired_backend_as_failed_command(tmp_path):
         )
     )
 
-    result = executor.run_command("python -c \"print('ok')\"", cwd=worktree, timeout_seconds=30)
+    result = executor.run_command("pytest -q", cwd=worktree, timeout_seconds=45)
+
+    sync_command = calls["commands"][0]
+    run_command = calls["commands"][1]
+
+    assert result.returncode == 0
+    assert result.stdout == "ok\n"
+    assert result.sandbox is not None
+    assert result.sandbox["backend"] == "e2b"
+    assert result.sandbox["workspace_sync"] == "upload_only"
+    assert result.sandbox["remote_sandbox_id"] == "sbx_123"
+    assert calls["create"]["allow_internet_access"] is False
+    assert calls["write"]["path"] == "/tmp/hive-mounts.tar.gz"
+    assert sync_command["cmd"].startswith("mkdir -p /workspace /artifacts && tar -xzf")
+    assert run_command["kwargs"]["cwd"] == "/workspace"
+    assert calls["killed"] is True
+
+
+def test_local_executor_reports_missing_e2b_sdk(monkeypatch, tmp_path):
+    worktree = tmp_path / "worktree"
+    artifacts = tmp_path / "artifacts"
+    worktree.mkdir()
+    artifacts.mkdir()
+    monkeypatch.setattr(
+        "src.hive.runs.executors._load_e2b_sdk",
+        lambda: (_ for _ in ()).throw(ImportError("sandbox-e2b missing")),
+    )
+
+    executor = LocalExecutor(
+        SandboxPolicy(
+            backend="e2b",
+            isolation_class="managed-sandbox",
+            network={"mode": "deny", "allowlist": []},
+            mounts={
+                "read_only": [],
+                "read_write": [str(worktree), str(artifacts)],
+                "container_worktree": "/workspace",
+                "container_artifacts": "/artifacts",
+            },
+            resources={"cpu": None, "memory_mb": None, "disk_mb": None, "wall_clock_sec": None},
+            env={"inherit": False, "allowlist": [], "passthrough": []},
+            snapshot=False,
+            resume=False,
+            profile="hosted-managed",
+            provenance="sandbox_v2_backend:e2b",
+        )
+    )
+
+    result = executor.run_command("pytest -q", cwd=worktree, timeout_seconds=45)
 
     assert result.returncode == 1
-    assert result.timed_out is False
-    assert "not wired into the local executor yet" in result.stderr
+    assert "sandbox-e2b" in result.stderr
+    assert result.sandbox is not None
+    assert result.sandbox["backend"] == "e2b"
 
 
 def test_execute_local_safe_wraps_python_runner_in_container(monkeypatch, tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -122,6 +122,15 @@ wheels = [
 ]
 
 [[package]]
+name = "bracex"
+version = "2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642, upload-time = "2025-06-22T19:12:31.254Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508, upload-time = "2025-06-22T19:12:29.781Z" },
+]
+
+[[package]]
 name = "build"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -407,12 +416,42 @@ wheels = [
 ]
 
 [[package]]
+name = "dockerfile-parse"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/df/929ee0b5d2c8bd8d713c45e71b94ab57c7e11e322130724d54f469b2cd48/dockerfile-parse-2.0.1.tar.gz", hash = "sha256:3184ccdc513221983e503ac00e1aa504a2aa8f84e5de673c46b0b6eee99ec7bc", size = 24556, upload-time = "2023-07-18T13:36:07.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/6c/79cd5bc1b880d8c1a9a5550aa8dacd57353fa3bb2457227e1fb47383eb49/dockerfile_parse-2.0.1-py2.py3-none-any.whl", hash = "sha256:bdffd126d2eb26acf1066acb54cb2e336682e1d72b974a40894fac76a4df17f6", size = 14845, upload-time = "2023-07-18T13:36:06.052Z" },
+]
+
+[[package]]
 name = "docutils"
 version = "0.22.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
+name = "e2b"
+version = "2.15.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "dockerfile-parse" },
+    { name = "httpcore" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "python-dateutil" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+    { name = "wcmatch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/d5/7e1ed4581e5400553904d7a941a4c0bd2869d78ab628e28f11585b237f6e/e2b-2.15.3.tar.gz", hash = "sha256:a15da5162db88d46dfa3593b08d9b3b31bb5fac36ba66c7e6ae3b652f56c06d8", size = 139981, upload-time = "2026-03-18T08:05:45.389Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/16/63832fa2c73c401fd7b0d8b24c51fe9775effc83c33af1e96e3f4c8fe715/e2b-2.15.3-py3-none-any.whl", hash = "sha256:0934f69f93f42cc4ef19415af003b13eb12d4e721b06f0ffa5aac91e6cf7c6b8", size = 257278, upload-time = "2026-03-18T08:05:43.717Z" },
 ]
 
 [[package]]
@@ -896,6 +935,9 @@ dev = [
 mcp = [
     { name = "mcp" },
 ]
+sandbox-e2b = [
+    { name = "e2b" },
+]
 tracing = [
     { name = "weave" },
 ]
@@ -904,6 +946,7 @@ tracing = [
 requires-dist = [
     { name = "black", marker = "extra == 'dev'", specifier = ">=25.11.0,<26.0.0" },
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.3.0,<2.0.0" },
+    { name = "e2b", marker = "extra == 'sandbox-e2b'", specifier = ">=2.2.5,<3.0.0" },
     { name = "fastapi", marker = "extra == 'all'", specifier = ">=0.115.0,<1.0.0" },
     { name = "fastapi", marker = "extra == 'console'", specifier = ">=0.115.0,<1.0.0" },
     { name = "fastapi", marker = "extra == 'coordinator'", specifier = ">=0.115.0,<1.0.0" },
@@ -930,7 +973,7 @@ requires-dist = [
     { name = "weave", marker = "extra == 'dev'", specifier = ">=0.51.0,<1.0.0" },
     { name = "weave", marker = "extra == 'tracing'", specifier = ">=0.51.0,<1.0.0" },
 ]
-provides-extras = ["dashboard", "console", "mcp", "coordinator", "tracing", "all", "dev"]
+provides-extras = ["dashboard", "sandbox-e2b", "console", "mcp", "coordinator", "tracing", "all", "dev"]
 
 [[package]]
 name = "more-itertools"
@@ -1608,6 +1651,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1950,6 +2005,15 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "smmap"
 version = "5.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2127,6 +2191,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/6d/e78093d49d68afb26f5261a70fc7877c34c114af5c2ee0ab3b1af85f5e76/wandb-0.23.1-py3-none-win32.whl", hash = "sha256:fb5cf0f85692f758a5c36ab65fea96a1284126de64e836610f92ddbb26df5ded", size = 22150756, upload-time = "2025-12-03T02:25:02.734Z" },
     { url = "https://files.pythonhosted.org/packages/05/27/4f13454b44c9eceaac3d6e4e4efa2230b6712d613ff9bf7df010eef4fd18/wandb-0.23.1-py3-none-win_amd64.whl", hash = "sha256:21c8c56e436eb707b7d54f705652e030d48e5cfcba24cf953823eb652e30e714", size = 22150760, upload-time = "2025-12-03T02:25:05.106Z" },
     { url = "https://files.pythonhosted.org/packages/30/20/6c091d451e2a07689bfbfaeb7592d488011420e721de170884fedd68c644/wandb-0.23.1-py3-none-win_arm64.whl", hash = "sha256:8aee7f3bb573f2c0acf860f497ca9c684f9b35f2ca51011ba65af3d4592b77c1", size = 20137463, upload-time = "2025-12-03T02:25:08.317Z" },
+]
+
+[[package]]
+name = "wcmatch"
+version = "10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bracex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/3e/c0bdc27cf06f4e47680bd5803a07cb3dfd17de84cde92dd217dcb9e05253/wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af", size = 117421, upload-time = "2025-06-22T19:14:02.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a", size = 39854, upload-time = "2025-06-22T19:14:00.978Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add a real hosted-managed executor path for `e2b` using the optional Python SDK
- make sandbox policy selection require a configured backend and surface clearer readiness blockers
- add packaging and runtime coverage for the new E2B path while keeping unwired backends failing honestly

## Testing
- make check