### PR TITLE
Review Draft PRs And Restore Sticky Claude Comments

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -57,6 +57,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           trigger_phrase: "@claude"
+          use_sticky_comment: true
           prompt: |
             REPO: ${{ github.repository }}
             EVENT NAME: ${{ github.event_name }}
@@ -72,7 +73,8 @@ jobs:
             --allowedTools "Bash(*),Read,Write,Edit,Glob,Grep,TodoWrite"
 
   claude-review:
-    if: github.event_name == 'pull_request' && !github.event.pull_request.draft
+    # Review both draft and ready PRs so long-running implementation branches get early signal.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/tests/test_claude_workflow.py
+++ b/tests/test_claude_workflow.py
@@ -20,3 +20,16 @@ def test_claude_workflows_discourage_raw_log_dump_comments():
         assert "Summarize command results in prose" in prompt
         assert "workflow or job URL for full logs" in prompt
     assert "Only publish the final GitHub comment or PR update" in response_prompt
+
+
+def test_claude_workflow_reviews_draft_prs_and_uses_sticky_comments():
+    """Draft PR review should stay enabled and mention replies should stay contained."""
+    workflow_path = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "claude.yml"
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+
+    response_with = workflow["jobs"]["claude-response"]["steps"][-1]["with"]
+    review_if = workflow["jobs"]["claude-review"]["if"]
+
+    assert response_with["use_sticky_comment"] is True
+    assert "!github.event.pull_request.draft" not in review_if
+    assert "github.event_name == 'pull_request'" in review_if


### PR DESCRIPTION
## Summary
- restore sticky comment behavior for interactive Claude responses so verbose output stays contained
- review draft PRs as well as ready PRs so long-running branches get earlier feedback
- lock the intended workflow behavior with focused tests

## Validation
- `uv run pytest tests/test_claude_workflow.py tests/test_claude_trigger_normalizer.py -q`
- `make check`

## Notes
- untouched local files remain untracked: `.hive/events/2026-03-18.jsonl`, `docs/V2_2_4_ONBOARDING_POLISH.md`