### PR TITLE
Lock v2.3 release scope

### DIFF
--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -43,6 +43,7 @@ Useful local commands:
 - `hive run cleanup --terminal` prunes linked worktrees left behind by terminal runs
 
 For the current release train, keep [docs/V2_3_STATUS.md](./V2_3_STATUS.md) up to date as the compact v2.3 execution ledger.
+Use the explicit scope-lock notes there as the current release truth if they narrow older proposed RFC items.
 
 ## Install Paths While Developing
 

--- a/docs/V2_3_STATUS.md
+++ b/docs/V2_3_STATUS.md
@@ -7,6 +7,22 @@ Purpose: compact execution ledger for the current v2.3 release line
 This file is the maintainer-facing status ledger for v2.3. Update it when a v2.3
 merge changes release readiness or moves the next blocker.
 
+## Scope Lock
+
+The v2.3 release scope is now explicitly locked to the work that is already close
+to release quality:
+
+- Codex and Claude must ship as deep, truthful, live drivers.
+- Local, hosted, and self-hosted sandbox paths must meet the release acceptance bar.
+- Retrieval must be packaged, explainable, and traceable in installed environments.
+- Campaigns, console surfaces, and docs/demo material must match the shipped product.
+
+The following items are explicitly deferred from blocking the v2.3 release:
+
+- Pi remains available as an honest staged driver, but full RPC depth moves to a later release.
+- The full hybrid retrieval stack from the proposed RFC (for example LanceDB, FastEmbed,
+  and Qdrant-backed retrieval) moves to a later release.
+
 ## Release Gate Ledger
 
 | Gate | Status | Evidence | Remaining blocker |
@@ -17,10 +33,10 @@ merge changes release readiness or moves the next blocker.
 | One real local sandbox path | Partial | `#117`, `#128`, `src/hive/sandbox/runtime.py`, `src/hive/sandbox/registry.py` | Final release-grade validation of `local-safe` versus `local-fast`, docs, and operator guidance |
 | One real hosted sandbox path | Partial | `#124`, `#132`, `src/hive/runs/executors.py` | Final acceptance validation for E2B behavior and docs |
 | One real self-hosted sandbox path | Partial | `#125`, `#127`, `#133`, `src/hive/runs/executors.py` | Final acceptance validation for Daytona behavior and docs |
-| Retrieval traces and explainability | Partial | `retrieval/trace.json`, `retrieval/hits.json`, `src/hive/runs/paths.py`, `src/hive/console/state.py` | Full hybrid retrieval engine is still not landed |
+| Explainable retrieval, packaged corpus, and traces | Partial | `retrieval/trace.json`, `retrieval/hits.json`, `src/hive/runs/paths.py`, `src/hive/console/state.py`, `tests/test_install_story.py` | Final installed-package usefulness check and docs/demo alignment |
 | Campaign candidate and decision artifacts | Complete | `candidate-set.json`, `decision.json`, `src/hive/control/campaigns.py`, `frontend/console/src/routes/CampaignDetailPage.tsx`, `frontend/console/src/test/observeConsole.smoke.test.tsx` | Final release/demo validation only |
 | Observe-and-steer console at RFC depth | Complete | `frontend/console/src/routes/RunDetailPage.tsx`, `frontend/console/src/routes/InboxPage.tsx`, `frontend/console/src/routes/CampaignDetailPage.tsx`, `tests/test_console_frontend_story.py`, `frontend/console/src/test/observeConsole.smoke.test.tsx` | Final release/demo validation only |
-| Pi driver at acceptance bar | Pending | none | Decide whether Pi remains a v2.3 requirement or explicitly moves to later |
+| Pi driver at acceptance bar | Deferred | `src/hive/drivers/pi.py`, `docs/hive-v2.3-rfc/HIVE_V2_3_RUNTIME_AND_SANDBOX_SPEC.md` | Keep staged truthfulness intact and carry full RPC depth to the next release line |
 | Release docs, demo, and acceptance alignment | Pending | `docs/`, `docs/hive-v2.3-rfc/`, `tests/test_v23_runtime_foundation.py` | Tighten scope and prove the final release story end-to-end |
 
 ## Current Read
@@ -32,22 +48,22 @@ What is real now:
 - approval truthfulness and runtime event/artifact plumbing are no longer just scaffolding
 - local, hosted, and self-hosted sandbox paths all exist in code and tests
 - the shipped operator console now surfaces capability truth, sandbox policy, retrieval traces, approval actions, and campaign decision reasoning
+- Pi no longer blocks the v2.3 release; the current staged driver remains available and honest
+- the release retrieval bar is now explainability, provenance, packaged corpus coverage, and trace persistence rather than the full hybrid backend stack
 
 What is still holding back a clean release call:
 
 - final acceptance and operator-grade validation for the sandbox matrix
-- final decision on Pi scope for v2.3
-- retrieval and campaign depth versus the RFC bar
+- installed-package retrieval usefulness and final operator-grade retrieval/docs validation
 - docs, console, and demo alignment so the shipped story matches the implementation
 
 ## Next Blocker
 
-Lock the remaining release scope and turn the rest of v2.3 into a short
-acceptance-driven train:
+Close the remaining acceptance-driven train against the scope-locked release:
 
-1. decide whether Pi and the full hybrid retrieval stack stay in v2.3 scope or are explicitly deferred
-2. land the sandbox acceptance-and-docs slice for `local-safe`, E2B, and Daytona
-3. align public docs and demo collateral with the real v2.3 operator story
+1. land the sandbox acceptance-and-docs slice for `local-safe`, E2B, and Daytona
+2. align public docs and demo collateral with the real v2.3 operator story
+3. finish the installed-package retrieval usefulness and release-demo validation pass
 
 ## Update Rule
 

--- a/tests/test_maintainer_surfaces.py
+++ b/tests/test_maintainer_surfaces.py
@@ -19,10 +19,13 @@ def test_v23_status_doc_tracks_release_gates_and_next_blocker():
     status_doc = (REPO_ROOT / "docs" / "V2_3_STATUS.md").read_text(encoding="utf-8")
 
     assert "# Hive v2.3 Status" in status_doc
+    assert "## Scope Lock" in status_doc
     assert "## Release Gate Ledger" in status_doc
     assert "## Next Blocker" in status_doc
     assert "Deep Claude live driver with SDK adapter and approval bridging" in status_doc
     assert "One real hosted sandbox path" in status_doc
+    assert "Pi driver at acceptance bar | Deferred" in status_doc
+    assert "full hybrid retrieval stack" in status_doc
 
 
 def test_pull_request_template_enforces_slice_and_review_discipline():
@@ -73,6 +76,7 @@ def test_repo_relies_on_managed_claude_review_instead_of_repo_local_workflow():
     assert "An `eyes` reaction alone is not completion." in install_doc
     assert "local Claude review is an acceptable primary or fallback path" in maintaining_doc
     assert 'claude -p "/review <pr-number>"' in maintaining_doc
+    assert "Use the explicit scope-lock notes there as the current release truth" in maintaining_doc
     assert "An `eyes` reaction alone does not count as completion." in agents_doc
     assert "An `eyes` reaction alone does not count as completion." in claude_doc
     assert 'claude -p "/review <pr-number>"' in skill_doc


### PR DESCRIPTION
## Blocker Removed

Locks the remaining v2.3 release scope so the closure train can focus on real blockers instead of carrying stale RFC breadth.

## Why This Slice Is Mergeable

This is a maintainer-surface slice only:
- records the explicit scope lock in `docs/V2_3_STATUS.md`
- makes the maintainer guide defer to that scope lock when it narrows older proposed RFC items
- adds regression coverage so this guidance does not drift

## Validation

- `uv run pytest tests/test_maintainer_surfaces.py -q`

## Review Discipline

- local Claude review will be attached to this PR
- a requested Claude review is not complete until there is a new review artifact on the latest head
- reactions alone do not count as completion
