### PR TITLE
Add CI-backed local-safe sandbox proof

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,75 @@ jobs:
       - name: Run driver and console conformance fixtures
         run: uv run pytest tests/test_hive_drivers.py tests/test_console_api.py tests/test_event_schema.py -q
 
+  sandbox-local-safe-proof:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Install Podman when missing
+        run: |
+          if command -v podman >/dev/null 2>&1; then
+            podman --version
+            exit 0
+          fi
+          sudo apt-get update
+          sudo apt-get install -y podman uidmap slirp4netns fuse-overlayfs
+          podman --version
+
+      - name: Verify rootless Podman availability
+        run: |
+          podman info --format json > podman-info.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          payload = json.loads(Path("podman-info.json").read_text(encoding="utf-8"))
+          rootless = bool(((payload.get("host") or {}).get("security") or {}).get("rootless", False))
+          if not rootless:
+              raise SystemExit("Podman is available but not running rootless on this runner.")
+          print("Podman rootless mode is available.")
+          PY
+
+      - name: Verify Hive sees Podman as local-safe
+        run: |
+          uv run hive sandbox doctor podman --json > podman-doctor.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          payload = json.loads(Path("podman-doctor.json").read_text(encoding="utf-8"))
+          backend = payload["backends"][0]
+          if backend.get("available") is not True:
+              raise SystemExit("Hive did not detect Podman on this runner.")
+          if backend.get("configured") is not True:
+              raise SystemExit("Hive detected Podman but did not consider it configured.")
+          if backend.get("evidence", {}).get("rootless") is not True:
+              raise SystemExit("Hive did not detect rootless Podman.")
+          if "local-safe" not in backend.get("supported_profiles", []):
+              raise SystemExit("Hive did not advertise Podman as local-safe.")
+          print("Hive sandbox doctor confirms Podman as local-safe.")
+          PY
+
+      - name: Run local-safe Podman acceptance proof
+        env:
+          HIVE_RUN_LOCAL_SAFE_ACCEPTANCE: "1"
+          HIVE_SANDBOX_IMAGE: "python:3.11-slim"
+        run: uv run pytest tests/test_local_safe_acceptance.py -q
+
   console-frontend-smoke:
     runs-on: ubuntu-latest
 

--- a/docs/V2_3_STATUS.md
+++ b/docs/V2_3_STATUS.md
@@ -30,7 +30,7 @@ The following items are explicitly deferred from blocking the v2.3 release:
 | Runtime contract, truthful capabilities, and standardized run artifacts | Complete | `#118`, `#119`, `#122`, `#123`, `src/hive/runtime/*`, `src/hive/runs/paths.py` | Keep compatibility and docs aligned as the remaining gates land |
 | Deep Codex live driver with approval bridging | Complete | `#116`, `#120`, `#123`, `tests/test_hive_drivers.py` | Final release/demo validation only |
 | Deep Claude live driver with SDK adapter and approval bridging | Complete | `#122`, `#127`, `#130`, `#136`, `src/hive/drivers/claude_sdk.py` | Final release/demo validation only |
-| One real local sandbox path | Partial | `#117`, `#128`, `src/hive/sandbox/runtime.py`, `src/hive/sandbox/registry.py`, `docs/recipes/sandbox-doctor.md` | Need one real CI-backed Podman acceptance proof after the truthfulness/docs pass |
+| One real local sandbox path | Complete | `#117`, `#128`, `src/hive/sandbox/runtime.py`, `src/hive/sandbox/registry.py`, `docs/recipes/sandbox-doctor.md`, `.github/workflows/ci.yml`, `tests/test_local_safe_acceptance.py` | Final release/demo validation only |
 | One real hosted sandbox path | Partial | `#124`, `#132`, `src/hive/runs/executors.py`, `docs/recipes/sandbox-doctor.md` | E2B execution is real for ephemeral upload-only runs, but pause/resume mapping is still missing |
 | One real self-hosted sandbox path | Partial | `#125`, `#127`, `#133`, `src/hive/runs/executors.py`, `docs/recipes/sandbox-doctor.md` | Needs final real-environment release validation after the docs/truthfulness pass |
 | Explainable retrieval, packaged corpus, and traces | Partial | `retrieval/trace.json`, `retrieval/hits.json`, `src/hive/runs/paths.py`, `src/hive/console/state.py`, `tests/test_install_story.py` | Final installed-package usefulness check and docs/demo alignment |
@@ -51,10 +51,10 @@ What is real now:
 - Pi no longer blocks the v2.3 release; the current staged driver remains available and honest
 - the release retrieval bar is now explainability, provenance, packaged corpus coverage, and trace persistence rather than the full hybrid backend stack
 - sandbox doctor and install docs now describe the real backend shapes and optional extras instead of leaving them buried in the RFC
+- the local-safe sandbox path now has a real Podman-backed CI proof instead of only mocked contract coverage
 
 What is still holding back a clean release call:
 
-- one real CI-backed `local-safe` proof
 - E2B pause/resume mapping or an explicit release-grade narrowing of that hosted acceptance bar
 - final real-environment validation for Daytona
 - installed-package retrieval usefulness and final operator-grade retrieval/docs validation
@@ -64,7 +64,7 @@ What is still holding back a clean release call:
 
 Close the remaining acceptance-driven train against the scope-locked release:
 
-1. finish the sandbox matrix with one real `local-safe` proof and an explicit decision on E2B pause/resume mapping
+1. finish the hosted and self-hosted sandbox story with an explicit E2B pause/resume decision and final Daytona release validation
 2. align public docs and demo collateral with the real v2.3 operator story
 3. finish the installed-package retrieval usefulness and release-demo validation pass
 

--- a/tests/test_local_safe_acceptance.py
+++ b/tests/test_local_safe_acceptance.py
@@ -1,0 +1,93 @@
+"""Real local-safe acceptance proof for CI runners with rootless Podman."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from src.hive.runs.executors import LocalExecutor
+from src.hive.sandbox.registry import get_backend
+from src.hive.sandbox.runtime import resolve_sandbox_policy
+
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("HIVE_RUN_LOCAL_SAFE_ACCEPTANCE") != "1",
+    reason="Set HIVE_RUN_LOCAL_SAFE_ACCEPTANCE=1 to run the real Podman acceptance proof.",
+)
+
+
+def _assert_podman_rootless_probe() -> None:
+    probe = get_backend("podman").probe()
+
+    assert probe.available is True
+    assert probe.configured is True
+    assert probe.supported_profiles == ["local-safe"]
+    assert (probe.evidence or {}).get("binary")
+    assert (probe.evidence or {}).get("rootless") is True
+
+
+def _local_safe_executor(tmp_path: Path) -> tuple[Path, Path, LocalExecutor]:
+    worktree = tmp_path / "workspace"
+    artifacts = tmp_path / "artifacts"
+    worktree.mkdir()
+    artifacts.mkdir()
+
+    policy = resolve_sandbox_policy(
+        worktree_path=str(worktree),
+        artifacts_path=str(artifacts),
+        profile="local-safe",
+    )
+
+    assert policy.backend == "podman"
+    assert policy.profile == "local-safe"
+    assert policy.network["mode"] == "deny"
+    return worktree, artifacts, LocalExecutor(policy)
+
+
+def test_local_safe_podman_executes_real_command(tmp_path):
+    """A real Podman-backed local-safe run should execute inside the mounted worktree."""
+    _assert_podman_rootless_probe()
+    worktree, artifacts, executor = _local_safe_executor(tmp_path)
+    (worktree / "input.txt").write_text("sandbox proof\n", encoding="utf-8")
+
+    result = executor.run_command(
+        (
+            "python -c \"from pathlib import Path; "
+            "print(Path.cwd()); "
+            "print(Path('input.txt').read_text().strip()); "
+            "Path('output.txt').write_text('ok\\n', encoding='utf-8')\""
+        ),
+        cwd=worktree,
+        timeout_seconds=120,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.timed_out is False
+    assert result.sandbox is not None
+    assert result.sandbox["backend"] == "podman"
+    assert result.sandbox["profile"] == "local-safe"
+    assert result.sandbox["network_mode"] == "deny"
+    assert "/workspace" in result.stdout
+    assert "sandbox proof" in result.stdout
+    assert (worktree / "output.txt").read_text(encoding="utf-8") == "ok\n"
+    assert artifacts.is_dir()
+
+
+def test_local_safe_podman_denies_outbound_network(tmp_path):
+    """The real local-safe Podman path should keep outbound networking disabled by default."""
+    _assert_podman_rootless_probe()
+    worktree, _artifacts, executor = _local_safe_executor(tmp_path)
+
+    result = executor.run_command(
+        'python -c "import socket; socket.create_connection((\'1.1.1.1\', 80), 2)"',
+        cwd=worktree,
+        timeout_seconds=30,
+    )
+
+    assert result.returncode not in (None, 0)
+    assert result.timed_out is False
+    assert result.sandbox is not None
+    assert result.sandbox["backend"] == "podman"
+    assert result.sandbox["network_mode"] == "deny"

--- a/tests/test_maintainer_surfaces.py
+++ b/tests/test_maintainer_surfaces.py
@@ -58,6 +58,22 @@ def test_ci_workflow_cancels_superseded_runs():
     assert "github.event.pull_request.number || github.ref" in workflow["concurrency"]["group"]
 
 
+def test_ci_workflow_proves_local_safe_podman_path():
+    """CI should carry one real Podman-backed proof for the local-safe sandbox gate."""
+    workflow = _load_yaml(".github/workflows/ci.yml")
+    job = workflow["jobs"]["sandbox-local-safe-proof"]
+    steps = job["steps"]
+
+    assert job["runs-on"] == "ubuntu-latest"
+    assert any(step.get("name") == "Verify rootless Podman availability" for step in steps)
+    assert any(step.get("name") == "Verify Hive sees Podman as local-safe" for step in steps)
+    assert any(
+        "tests/test_local_safe_acceptance.py" in step.get("run", "")
+        for step in steps
+        if isinstance(step.get("run"), str)
+    )
+
+
 def test_repo_relies_on_managed_claude_review_instead_of_repo_local_workflow():
     """Claude review should come from Anthropic's managed app, not a repo-local workflow."""
     install_doc = (REPO_ROOT / "docs" / "INSTALL_CLAUDE_APP.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Blocker Removed

Close the remaining local sandbox acceptance blocker by adding one real CI-backed proof for the `local-safe` Podman path.

## Why This Slice Is Mergeable

This PR stays on one release gate:
- adds a dedicated CI job that verifies rootless Podman availability
- proves `hive sandbox doctor` reports Podman as `local-safe`
- runs a real Podman-backed acceptance test for command execution and deny-by-default networking
- updates the v2.3 ledger to mark the local sandbox gate complete

## Validation

- `uv run pytest tests/test_local_safe_acceptance.py tests/test_maintainer_surfaces.py -q`
- `uv run pytest tests/test_release_tooling.py tests/test_install_story.py -q`
- `make check`
  - result: `582 passed, 2 skipped, 1 warning`

## Review Discipline

- requesting managed `@claude review`
- I will also run local Claude review on this PR head
- an `eyes` reaction alone does not count as completion
