### PR TITLE
Record Daytona proof in v2.3 ledger

### DIFF
--- a/docs/V2_3_STATUS.md
+++ b/docs/V2_3_STATUS.md
@@ -32,7 +32,7 @@ The following items are explicitly deferred from blocking the v2.3 release:
 | Deep Claude live driver with SDK adapter and approval bridging | Complete | `#122`, `#127`, `#130`, `#136`, `src/hive/drivers/claude_sdk.py` | Final release/demo validation only |
 | One real local sandbox path | Complete | `#117`, `#128`, `src/hive/sandbox/runtime.py`, `src/hive/sandbox/registry.py`, `docs/recipes/sandbox-doctor.md`, `.github/workflows/ci.yml`, `tests/test_local_safe_acceptance.py` | Final release/demo validation only |
 | One real hosted sandbox path | Complete | `#124`, `#132`, `src/hive/runs/executors.py`, `docs/recipes/sandbox-doctor.md`, `docs/hive-v2.3-rfc/HIVE_V2_3_ACCEPTANCE_TESTS.md`, `tests/test_remote_sandbox_acceptance.py` | Final release/demo validation only |
-| One real self-hosted sandbox path | Partial | `#125`, `#127`, `#133`, `src/hive/runs/executors.py`, `docs/recipes/sandbox-doctor.md`, `tests/test_remote_sandbox_acceptance.py` | Run the opt-in Daytona acceptance proof in a credentialed environment and fold the result into the release call |
+| One real self-hosted sandbox path | Complete | `#125`, `#127`, `#133`, `src/hive/runs/executors.py`, `docs/recipes/sandbox-doctor.md`, `tests/test_remote_sandbox_acceptance.py`, `2026-03-19 live Daytona proof (1 passed)` | Final release/demo validation only |
 | Explainable retrieval, packaged corpus, and traces | Partial | `retrieval/trace.json`, `retrieval/hits.json`, `src/hive/runs/paths.py`, `src/hive/console/state.py`, `tests/test_install_story.py` | Final installed-package usefulness check and docs/demo alignment |
 | Campaign candidate and decision artifacts | Complete | `candidate-set.json`, `decision.json`, `src/hive/control/campaigns.py`, `frontend/console/src/routes/CampaignDetailPage.tsx`, `frontend/console/src/test/observeConsole.smoke.test.tsx` | Final release/demo validation only |
 | Observe-and-steer console at RFC depth | Complete | `frontend/console/src/routes/RunDetailPage.tsx`, `frontend/console/src/routes/InboxPage.tsx`, `frontend/console/src/routes/CampaignDetailPage.tsx`, `tests/test_console_frontend_story.py`, `frontend/console/src/test/observeConsole.smoke.test.tsx` | Final release/demo validation only |
@@ -52,10 +52,10 @@ What is real now:
 - the release retrieval bar is now explainability, provenance, packaged corpus coverage, and trace persistence rather than the full hybrid backend stack
 - sandbox doctor and install docs now describe the real backend shapes and optional extras instead of leaving them buried in the RFC
 - the local-safe sandbox path now has a real Podman-backed CI proof instead of only mocked contract coverage
+- the Daytona self-hosted proof now passed in a credentialed environment using `DAYTONA_API_URL` + `DAYTONA_API_KEY`
 
 What is still holding back a clean release call:
 
-- final real-environment validation for Daytona through the new opt-in acceptance proof
 - installed-package retrieval usefulness and final operator-grade retrieval/docs validation
 - docs, console, and demo alignment so the shipped story matches the implementation
 
@@ -63,9 +63,9 @@ What is still holding back a clean release call:
 
 Close the remaining acceptance-driven train against the scope-locked release:
 
-1. run the Daytona self-hosted acceptance proof in a credentialed environment and record the result in the release call
-2. align public docs and demo collateral with the real v2.3 operator story
-3. finish the installed-package retrieval usefulness and release-demo validation pass
+1. align public docs and demo collateral with the real v2.3 operator story
+2. finish the installed-package retrieval usefulness and release-demo validation pass
+3. make the final release call against the now-closed runtime and sandbox gates
 
 ## Update Rule
 

--- a/tests/test_maintainer_surfaces.py
+++ b/tests/test_maintainer_surfaces.py
@@ -25,9 +25,11 @@ def test_v23_status_doc_tracks_release_gates_and_next_blocker():
     assert "Deep Claude live driver with SDK adapter and approval bridging" in status_doc
     assert "One real hosted sandbox path" in status_doc
     assert "One real hosted sandbox path | Complete" in status_doc
+    assert "One real self-hosted sandbox path | Complete" in status_doc
     assert "Pi driver at acceptance bar | Deferred" in status_doc
     assert "full hybrid retrieval stack" in status_doc
-    assert "run the Daytona self-hosted acceptance proof in a credentialed environment" in status_doc
+    assert "the Daytona self-hosted proof now passed in a credentialed environment" in status_doc
+    assert "align public docs and demo collateral with the real v2.3 operator story" in status_doc
 
 
 def test_v23_acceptance_doc_tracks_scope_locked_remote_sandbox_truth():


### PR DESCRIPTION
## Blocker Removed

Record the real Daytona self-hosted acceptance proof in the v2.3 execution ledger.

## Why This Slice Is Mergeable

This is a tiny evidence-only follow-up:
- no product code changes
- no contract changes
- just promotes the self-hosted sandbox gate from partial to complete based on a real credentialed proof run

## What Changed

- marks the self-hosted sandbox gate complete in `docs/V2_3_STATUS.md`
- records that the Daytona proof passed on 2026-03-19 using `DAYTONA_API_URL` + `DAYTONA_API_KEY`
- updates the maintainer-surface regression so the ledger stays aligned with the proven state

## Validation

- `uv run pytest tests/test_maintainer_surfaces.py -q`
  - `8 passed`
- `set -a && source .env && export HIVE_RUN_DAYTONA_ACCEPTANCE=1 && set +a && uv run --extra sandbox-daytona pytest tests/test_remote_sandbox_acceptance.py -k daytona -q`
  - `1 passed, 1 deselected`

## Review Discipline

Claude review is blocking for merge on the latest PR head. An `eyes` reaction alone does not count as completion.
