### PR TITLE
Align v2.3 release docs and demo story

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Agent Hive is a repo-native control plane for autonomous work. Keep your favorite worker harness, whether that is Codex, Claude Code, or a local/manual loop, and use Hive to supervise tasks, runs, memory, approvals, and campaigns from one place.
 
-The center of gravity in this repository is Hive 2.2:
+The center of gravity in this repository is the Hive v2 substrate, with the current release line focused on a truthful v2.3 operator surface:
 
 - `hive` is the primary interface.
 - `.hive/tasks/*.md` is the canonical task store.
@@ -182,7 +182,7 @@ The longer comparison lives in [docs/COMPARE_HARNESSES.md](docs/COMPARE_HARNESSE
 - [docs/START_HERE.md](docs/START_HERE.md) for the lane chooser and install matrix
 - [docs/QUICKSTART.md](docs/QUICKSTART.md) for the fresh-workspace walkthrough
 - [docs/ADOPT_EXISTING_REPO.md](docs/ADOPT_EXISTING_REPO.md) for existing repositories and legacy imports
-- [docs/DEMO_WALKTHROUGH.md](docs/DEMO_WALKTHROUGH.md) for the recorded v2.2 launch fixture, screenshots, and walkthrough flow
+- [docs/DEMO_WALKTHROUGH.md](docs/DEMO_WALKTHROUGH.md) for the current demo walkthrough, screenshots, and narration built on the multi-project launch fixture
 - [docs/COMPARE_HARNESSES.md](docs/COMPARE_HARNESSES.md) for Codex, Claude Code, and local/manual guidance
 - [docs/UI_INFORMATION_ARCHITECTURE.md](docs/UI_INFORMATION_ARCHITECTURE.md) for the console information architecture
 - [docs/OPERATOR_FLOWS.md](docs/OPERATOR_FLOWS.md) for the manager loop and steering flows
@@ -192,6 +192,6 @@ The longer comparison lives in [docs/COMPARE_HARNESSES.md](docs/COMPARE_HARNESSE
 
 ## Maintainers
 
-This repository runs on the same Hive 2.2 substrate it ships, but the source checkout is still a maintainer
+This repository runs on the same Hive v2 substrate it ships, but the source checkout is still a maintainer
 surface, not the normal installed-user path. If you are here to work on Hive itself, start with
 [docs/MAINTAINING.md](docs/MAINTAINING.md).

--- a/docs/DEMO_WALKTHROUGH.md
+++ b/docs/DEMO_WALKTHROUGH.md
@@ -1,14 +1,20 @@
-# Hive 2.2 Demo Walkthrough
+# Hive v2.3 Demo Walkthrough
 
-This is the shortest path to a real launch-quality demo of Hive 2.2.
+This is the shortest path to a truthful scope-locked v2.3 demo.
+
+It still builds on the existing multi-project launch fixture from the v2.2 line, so the builder
+and temp paths keep their `v22` names. The point of this walkthrough is to show the deeper v2.3
+operator surface on top of that stable fixture, not to replace the fixture itself.
 
 It builds the same north-star shape we use in acceptance:
 
 - three projects
-- ten runs across local, Codex, Claude Code, and manual flows
+- ten runs across local, Codex, Claude, and manual flows
 - a reroute with preserved lineage
 - a campaign-generated daily brief
 - accepted runs with evaluator evidence and context manifests
+- run detail with capability truth, sandbox policy, retrieval trace, and steering history
+- an inbox flow that shows approval handling without manual markdown edits
 
 ## 1. Build the demo workspace
 
@@ -76,8 +82,8 @@ without recreating the fixture first.
 
 1. Start on Home and show the recommendation, active runs, inbox, blockers, and campaign summary.
 2. Jump to Runs and point out that one operator can monitor the whole portfolio in one board.
-3. Open Inbox and show that approval and input requests land in one place without manual sync.
-4. Open the rerouted run detail and show the steering history, context inspector, evaluator evidence, and diff preview.
+3. Open Inbox and show that approval requests land in one place without manual sync.
+4. Open the rerouted run detail and show the capability snapshot, sandbox policy, retrieval inspector, steering history, evaluator evidence, and diff preview.
 5. Close on the idea that Hive is the control plane above the worker harness, not a replacement for it.
 
 ## 5. What this proves
@@ -86,6 +92,7 @@ This walkthrough is meant to make the release checklist concrete:
 
 - the operator can monitor multiple projects and runs in one console
 - steering is typed and visible in the audit trail
+- capability truth, sandbox truth, and retrieval explanations are visible without opening raw artifacts
 - accepted work can explain why it passed
 - campaigns and daily briefs are part of the same control surface
-- the same control plane can sit above Codex, Claude Code, local execution, and manual handoffs
+- the same control plane can sit above Codex, Claude, local execution, and manual handoffs

--- a/docs/OPERATOR_FLOWS.md
+++ b/docs/OPERATOR_FLOWS.md
@@ -1,6 +1,7 @@
 # Operator Flows
 
-Hive 2.2 assumes the operator mostly supervises and occasionally intervenes.
+Hive v2.3 assumes the operator mostly supervises, but it also gives explicit inspect-and-steer
+surfaces when a run or campaign needs intervention.
 
 Install `mellona-hive[console]` first anywhere you use `hive console serve` below.
 
@@ -45,7 +46,7 @@ CLI examples:
 
 ```bash
 hive steer pause <run-id> --reason "Waiting on a dependency" --json
-hive steer reroute <run-id> --driver claude-code --reason "Need broader repo search" --json
+hive steer reroute <run-id> --driver claude --reason "Need broader repo search" --json
 ```
 
 ## Program hardening loop
@@ -73,6 +74,9 @@ hive sandbox doctor daytona --json
 ```
 
 Use [docs/recipes/sandbox-doctor.md](./recipes/sandbox-doctor.md) for the profile map, optional extras, and current backend limitations.
+
+The current shipped operator story is: capability truth, sandbox truth, retrieval explanations,
+approval handling, and campaign reasoning from one console and one CLI.
 
 ## Campaign loop
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -49,6 +49,12 @@ That does five things:
 
 If `make release-check` fails, fix that before you tag anything.
 
+For the scoped v2.3 release line, do not call the release ready until these additional truthfulness
+checks are closed:
+
+1. README, demo walkthrough, compare-harness, and operator docs match the shipped observe-and-steer story.
+2. Installed-package `hive search` is proven useful from a throwaway install, not only from a source checkout.
+
 ## Cut A Release
 
 Bump the version:
@@ -145,6 +151,18 @@ hive onboard demo --title "Demo project"
 hive doctor --json
 hive task ready --project-id demo --json
 ```
+
+For the scoped v2.3 release line, also prove installed-package retrieval usefulness from that clean
+environment. At minimum, run one API/RFC query and one packaged recipe query without a source
+checkout on the `PYTHONPATH`:
+
+```bash
+hive search "runtime contract" --scope api --limit 5 --json
+hive search "sandbox doctor" --scope examples --limit 5 --json
+```
+
+The result should show packaged docs or recipes, not empty results, and the returned hits should
+include non-empty explanations. Record that proof before you call the retrieval gate complete.
 
 ## Optional Remote Sandbox Release Proofs
 

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -41,7 +41,8 @@ hive --version
 hive doctor
 ```
 
-If you are testing before the first tagged public release lands, use the git install instead:
+If you want the latest unreleased checkout before the next tagged release or before package
+indexes catch up, use the git install instead:
 
 ```bash
 uv tool install --from git+https://github.com/intertwine/hive-orchestrator.git mellona-hive

--- a/docs/V2_3_STATUS.md
+++ b/docs/V2_3_STATUS.md
@@ -37,7 +37,7 @@ The following items are explicitly deferred from blocking the v2.3 release:
 | Campaign candidate and decision artifacts | Complete | `candidate-set.json`, `decision.json`, `src/hive/control/campaigns.py`, `frontend/console/src/routes/CampaignDetailPage.tsx`, `frontend/console/src/test/observeConsole.smoke.test.tsx` | Final release/demo validation only |
 | Observe-and-steer console at RFC depth | Complete | `frontend/console/src/routes/RunDetailPage.tsx`, `frontend/console/src/routes/InboxPage.tsx`, `frontend/console/src/routes/CampaignDetailPage.tsx`, `tests/test_console_frontend_story.py`, `frontend/console/src/test/observeConsole.smoke.test.tsx` | Final release/demo validation only |
 | Pi driver at acceptance bar | Deferred | `src/hive/drivers/pi.py`, `docs/hive-v2.3-rfc/HIVE_V2_3_RUNTIME_AND_SANDBOX_SPEC.md` | Keep staged truthfulness intact and carry full RPC depth to the next release line |
-| Release docs, demo, and acceptance alignment | Pending | `docs/`, `docs/hive-v2.3-rfc/`, `tests/test_v23_runtime_foundation.py` | Tighten scope and prove the final release story end-to-end |
+| Release docs, demo, and acceptance alignment | Partial | `README.md`, `docs/DEMO_WALKTHROUGH.md`, `docs/OPERATOR_FLOWS.md`, `docs/START_HERE.md`, `docs/RELEASING.md`, `docs/hive-v2.3-rfc/HIVE_V2_3_ACCEPTANCE_TESTS.md`, `tests/test_launch_collateral.py`, `tests/test_maintainer_surfaces.py` | Finish the installed-package retrieval proof and the final release call |
 
 ## Current Read
 
@@ -53,19 +53,18 @@ What is real now:
 - sandbox doctor and install docs now describe the real backend shapes and optional extras instead of leaving them buried in the RFC
 - the local-safe sandbox path now has a real Podman-backed CI proof instead of only mocked contract coverage
 - the Daytona self-hosted proof now passed in a credentialed environment using `DAYTONA_API_URL` + `DAYTONA_API_KEY`
+- the public README, demo walkthrough, operator flows, and acceptance/release docs now describe the scoped v2.3 operator story instead of the older v2.2 launch framing
 
 What is still holding back a clean release call:
 
 - installed-package retrieval usefulness and final operator-grade retrieval/docs validation
-- docs, console, and demo alignment so the shipped story matches the implementation
 
 ## Next Blocker
 
 Close the remaining acceptance-driven train against the scope-locked release:
 
-1. align public docs and demo collateral with the real v2.3 operator story
-2. finish the installed-package retrieval usefulness and release-demo validation pass
-3. make the final release call against the now-closed runtime and sandbox gates
+1. finish the installed-package retrieval usefulness and release-demo validation pass
+2. make the final release call against the now-closed runtime and sandbox gates
 
 ## Update Rule
 

--- a/docs/hive-v2.3-rfc/HIVE_V2_3_ACCEPTANCE_TESTS.md
+++ b/docs/hive-v2.3-rfc/HIVE_V2_3_ACCEPTANCE_TESTS.md
@@ -8,9 +8,13 @@ Date: 2026-03-17
 One operator supervises:
 - 3 projects
 - 10 concurrent runs
-- across Codex, Claude, Pi, and one deterministic local helper
+- across Codex, Claude, and one deterministic local helper
 - from one console and one CLI
 - with one unified inbox for approvals and escalations
+
+Scope-locked v2.3 note:
+- Pi remains available as an honest staged driver, but full Pi RPC depth is deferred from this
+  release line.
 
 The release passes only if the operator can:
 - see all runs on one board
@@ -27,6 +31,10 @@ The release passes only if the operator can:
 
 ## Gate A — Runtime depth
 
+Scope-locked v2.3 note:
+- Codex and Claude are the mandatory deep-driver gates for this release.
+- Pi remains non-blocking for the scoped v2.3 release as long as the staged driver stays truthful.
+
 ### Codex
 - [ ] `hive driver doctor` reports Codex `app_server` availability accurately
 - [ ] Hive can launch an interactive Codex run through app-server
@@ -42,15 +50,15 @@ The release passes only if the operator can:
 - [ ] Hive can interrupt a Claude run
 - [ ] session continuity is visible in run detail
 
-### Pi
+### Manual / staged
+- [ ] staged driver does not claim streaming/resume/subagents as effective
+- [ ] console hides controls that the staged driver cannot support
+
+### Pi (deferred from the v2.3 release bar)
 - [ ] `hive driver doctor` reports Pi RPC availability accurately
 - [ ] Hive can launch Pi in RPC mode
 - [ ] Hive can ingest normalized events from Pi
 - [ ] Hive can terminate a Pi run cleanly
-
-### Manual / staged
-- [ ] staged driver does not claim streaming/resume/subagents as effective
-- [ ] console hides controls that the staged driver cannot support
 
 ## Gate B — Capability truthfulness
 
@@ -173,7 +181,7 @@ These are pragmatic local-product targets, not hard real-time guarantees.
 - continue in same session or relaunch with preserved lineage
 - confirm run detail shows both steps clearly
 
-## Scenario 3 — Pi headless scripted run
+## Scenario 3 — Pi headless scripted run (deferred from the scoped v2.3 release bar)
 - launch a Pi run in RPC mode
 - capture transcript and event stream
 - inspect capability snapshot

--- a/src/hive/search.py
+++ b/src/hive/search.py
@@ -1,4 +1,4 @@
-"""Workspace and API search surfaces for Hive 2.1."""
+"""Workspace and API search surfaces for the Hive v2 substrate."""
 
 from __future__ import annotations
 

--- a/tests/test_launch_collateral.py
+++ b/tests/test_launch_collateral.py
@@ -1,4 +1,4 @@
-"""Checks for the v2.2 demo collateral and walkthrough assets."""
+"""Checks for the current release demo collateral and walkthrough assets."""
 
 from __future__ import annotations
 
@@ -16,6 +16,8 @@ def test_demo_walkthrough_exists_and_points_to_real_commands():
     """The launch demo doc should tell a maintainer exactly how to build and capture the fixture."""
     demo = (REPO_ROOT / "docs" / "DEMO_WALKTHROUGH.md").read_text(encoding="utf-8")
 
+    assert "# Hive v2.3 Demo Walkthrough" in demo
+    assert "scope-locked v2.3 demo" in demo
     assert "scripts/build_v22_demo_workspace.py" in demo
     assert "frontend/console/scripts/captureDemoAssets.mjs" in demo
     assert "north_star_manifest.json" in demo
@@ -23,6 +25,8 @@ def test_demo_walkthrough_exists_and_points_to_real_commands():
     assert "observe-and-steer-demo.webm" in demo
     assert "console-home.png" in demo
     assert "console-run-detail.png" in demo
+    assert "capability truth" in demo
+    assert "retrieval inspector" in demo
 
 
 def test_readme_and_compare_docs_keep_the_control_plane_launch_story():
@@ -33,6 +37,7 @@ def test_readme_and_compare_docs_keep_the_control_plane_launch_story():
     assert "control plane" in readme.lower()
     assert "command center" in readme.lower()
     assert "docs/DEMO_WALKTHROUGH.md" in readme
+    assert "current release line focused on a truthful v2.3 operator surface" in readme
     assert "control plane above the worker harness" in compare.lower()
 
 

--- a/tests/test_maintainer_surfaces.py
+++ b/tests/test_maintainer_surfaces.py
@@ -29,7 +29,9 @@ def test_v23_status_doc_tracks_release_gates_and_next_blocker():
     assert "Pi driver at acceptance bar | Deferred" in status_doc
     assert "full hybrid retrieval stack" in status_doc
     assert "the Daytona self-hosted proof now passed in a credentialed environment" in status_doc
-    assert "align public docs and demo collateral with the real v2.3 operator story" in status_doc
+    assert "Release docs, demo, and acceptance alignment | Partial" in status_doc
+    assert "Finish the installed-package retrieval proof and the final release call" in status_doc
+    assert "finish the installed-package retrieval usefulness and release-demo validation pass" in status_doc
 
 
 def test_v23_acceptance_doc_tracks_scope_locked_remote_sandbox_truth():
@@ -42,6 +44,24 @@ def test_v23_acceptance_doc_tracks_scope_locked_remote_sandbox_truth():
     assert "E2B is release-accepted as an ephemeral upload-only hosted path." in acceptance_doc
     assert "E2B pause/resume and downloaded artifact sync are deferred" in acceptance_doc
     assert "Daytona truthfully documents upload-only sync and the current mount/network limits" in acceptance_doc
+    assert "Pi remains available as an honest staged driver" in acceptance_doc
+    assert "Pi (deferred from the v2.3 release bar)" in acceptance_doc
+
+
+def test_release_docs_require_scope_locked_v23_story_and_installed_search_proof():
+    """Release docs should require docs/demo alignment and installed retrieval proof for v2.3."""
+    release_doc = (REPO_ROOT / "docs" / "RELEASING.md").read_text(encoding="utf-8")
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    operator_doc = (REPO_ROOT / "docs" / "OPERATOR_FLOWS.md").read_text(encoding="utf-8")
+    start_here = (REPO_ROOT / "docs" / "START_HERE.md").read_text(encoding="utf-8")
+
+    assert "README, demo walkthrough, compare-harness, and operator docs" in release_doc
+    assert "Installed-package `hive search` is proven useful" in release_doc
+    assert 'hive search "runtime contract" --scope api --limit 5 --json' in release_doc
+    assert 'hive search "sandbox doctor" --scope examples --limit 5 --json' in release_doc
+    assert "truthful v2.3 operator surface" in readme
+    assert "Hive v2.3 assumes the operator mostly supervises" in operator_doc
+    assert "If you want the latest unreleased checkout" in start_here
 
 
 def test_pull_request_template_enforces_slice_and_review_discipline():


### PR DESCRIPTION
## Blocker Removed
Align the public docs, demo walkthrough, acceptance doc, release guide, and v2.3 ledger around the same scope-locked v2.3 story.

## Why This Slice Is Mergeable
This is a docs-and-guardrails-only slice. It does not change runtime behavior; it makes the public and maintainer surfaces truthful about what v2.3 does and does not ship, including Pi deferral and the remaining installed-search proof gate.

## Validation
- Focused docs/regression set:
  - tests/test_launch_collateral.py
  - tests/test_maintainer_surfaces.py
  - tests/test_install_story.py
  - tests/test_hive_v2.py -k "search or install_story or launch_collateral or maintainer_surfaces"
- Result: 37 passed, 89 deselected

## Review Discipline
I will treat Claude review as pending until there is a real review artifact on the latest PR head. Reactions alone do not count as completion, and I will watch the post-merge main CI run if this lands.