### PR TITLE
Prove installed search in release smoke checks

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -152,9 +152,10 @@ hive doctor --json
 hive task ready --project-id demo --json
 ```
 
-For the scoped v2.3 release line, also prove installed-package retrieval usefulness from that clean
-environment. At minimum, run one API/RFC query and one packaged recipe query without a source
-checkout on the `PYTHONPATH`:
+For the scoped v2.3 release line, the built-artifact smoke script now proves installed-package
+retrieval usefulness automatically for the `uv tool` install lane. If you are verifying manually or
+debugging a release candidate, run one API/RFC query and one packaged recipe query without a
+source checkout on the `PYTHONPATH`:
 
 ```bash
 hive search "runtime contract" --scope api --limit 5 --json

--- a/docs/V2_3_STATUS.md
+++ b/docs/V2_3_STATUS.md
@@ -33,11 +33,11 @@ The following items are explicitly deferred from blocking the v2.3 release:
 | One real local sandbox path | Complete | `#117`, `#128`, `src/hive/sandbox/runtime.py`, `src/hive/sandbox/registry.py`, `docs/recipes/sandbox-doctor.md`, `.github/workflows/ci.yml`, `tests/test_local_safe_acceptance.py` | Final release/demo validation only |
 | One real hosted sandbox path | Complete | `#124`, `#132`, `src/hive/runs/executors.py`, `docs/recipes/sandbox-doctor.md`, `docs/hive-v2.3-rfc/HIVE_V2_3_ACCEPTANCE_TESTS.md`, `tests/test_remote_sandbox_acceptance.py` | Final release/demo validation only |
 | One real self-hosted sandbox path | Complete | `#125`, `#127`, `#133`, `src/hive/runs/executors.py`, `docs/recipes/sandbox-doctor.md`, `tests/test_remote_sandbox_acceptance.py`, `2026-03-19 live Daytona proof (1 passed)` | Final release/demo validation only |
-| Explainable retrieval, packaged corpus, and traces | Partial | `retrieval/trace.json`, `retrieval/hits.json`, `src/hive/runs/paths.py`, `src/hive/console/state.py`, `tests/test_install_story.py` | Final installed-package usefulness check and docs/demo alignment |
+| Explainable retrieval, packaged corpus, and traces | Complete | `retrieval/trace.json`, `retrieval/hits.json`, `src/hive/runs/paths.py`, `src/hive/console/state.py`, `scripts/smoke_release_install.sh`, `tests/test_install_story.py`, `tests/test_release_tooling.py` | Final release/demo validation only |
 | Campaign candidate and decision artifacts | Complete | `candidate-set.json`, `decision.json`, `src/hive/control/campaigns.py`, `frontend/console/src/routes/CampaignDetailPage.tsx`, `frontend/console/src/test/observeConsole.smoke.test.tsx` | Final release/demo validation only |
 | Observe-and-steer console at RFC depth | Complete | `frontend/console/src/routes/RunDetailPage.tsx`, `frontend/console/src/routes/InboxPage.tsx`, `frontend/console/src/routes/CampaignDetailPage.tsx`, `tests/test_console_frontend_story.py`, `frontend/console/src/test/observeConsole.smoke.test.tsx` | Final release/demo validation only |
 | Pi driver at acceptance bar | Deferred | `src/hive/drivers/pi.py`, `docs/hive-v2.3-rfc/HIVE_V2_3_RUNTIME_AND_SANDBOX_SPEC.md` | Keep staged truthfulness intact and carry full RPC depth to the next release line |
-| Release docs, demo, and acceptance alignment | Partial | `README.md`, `docs/DEMO_WALKTHROUGH.md`, `docs/OPERATOR_FLOWS.md`, `docs/START_HERE.md`, `docs/RELEASING.md`, `docs/hive-v2.3-rfc/HIVE_V2_3_ACCEPTANCE_TESTS.md`, `tests/test_launch_collateral.py`, `tests/test_maintainer_surfaces.py` | Finish the installed-package retrieval proof and the final release call |
+| Release docs, demo, and acceptance alignment | Complete | `README.md`, `docs/DEMO_WALKTHROUGH.md`, `docs/OPERATOR_FLOWS.md`, `docs/START_HERE.md`, `docs/RELEASING.md`, `docs/hive-v2.3-rfc/HIVE_V2_3_ACCEPTANCE_TESTS.md`, `tests/test_launch_collateral.py`, `tests/test_maintainer_surfaces.py`, `scripts/smoke_release_install.sh`, `tests/test_release_tooling.py` | Final release/demo validation only |
 
 ## Current Read
 
@@ -54,17 +54,17 @@ What is real now:
 - the local-safe sandbox path now has a real Podman-backed CI proof instead of only mocked contract coverage
 - the Daytona self-hosted proof now passed in a credentialed environment using `DAYTONA_API_URL` + `DAYTONA_API_KEY`
 - the public README, demo walkthrough, operator flows, and acceptance/release docs now describe the scoped v2.3 operator story instead of the older v2.2 launch framing
+- the built-artifact release smoke path now proves installed-package `hive search` returns packaged API/RFC and recipe hits with explanations
 
 What is still holding back a clean release call:
 
-- installed-package retrieval usefulness and final operator-grade retrieval/docs validation
+- the actual v2.3 release decision, version/tag cut, and final demo/release verification against the now-closed gates
 
 ## Next Blocker
 
 Close the remaining acceptance-driven train against the scope-locked release:
 
-1. finish the installed-package retrieval usefulness and release-demo validation pass
-2. make the final release call against the now-closed runtime and sandbox gates
+1. make the final v2.3 release call against the now-closed runtime, sandbox, retrieval, campaign, console, and docs gates
 
 ## Update Rule
 

--- a/scripts/smoke_release_install.sh
+++ b/scripts/smoke_release_install.sh
@@ -45,6 +45,62 @@ resolve_release_python_bin() {
     exit 1
 }
 
+assert_search_payload() {
+    local python_bin="$1"
+    local json_path="$2"
+    local expected_kind="$3"
+    local expected_path_fragment="$4"
+
+    "$python_bin" - "$json_path" "$expected_kind" "$expected_path_fragment" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+json_path, expected_kind, expected_path_fragment = sys.argv[1:4]
+payload = json.loads(Path(json_path).read_text(encoding="utf-8"))
+results = payload.get("results") if isinstance(payload, dict) else payload
+if not isinstance(results, list) or not results:
+    raise SystemExit(f"Search payload {json_path} did not include any results.")
+
+matches = [
+    item
+    for item in results
+    if item.get("kind") == expected_kind
+    and expected_path_fragment in str(item.get("path", ""))
+]
+if not matches:
+    raise SystemExit(
+        f"Expected a {expected_kind} result containing {expected_path_fragment!r} in {json_path}."
+    )
+if not all(str(item.get("explanation", "")).strip() for item in matches):
+    raise SystemExit(f"Matched results in {json_path} were missing explanations.")
+PY
+}
+
+run_installed_search_smoke() {
+    local hive_bin="$1"
+    local workspace="$2"
+    local python_bin
+    local api_json="$TEMP_ROOT/installed-api-search.json"
+    local examples_json="$TEMP_ROOT/installed-examples-search.json"
+
+    python_bin="$(resolve_release_python_bin)"
+
+    "$hive_bin" --path "$workspace" search "runtime contract" --scope api --limit 5 --json >"$api_json"
+    "$hive_bin" --path "$workspace" search "sandbox doctor" --scope examples --limit 5 --json >"$examples_json"
+
+    assert_search_payload \
+        "$python_bin" \
+        "$api_json" \
+        "api" \
+        "package:docs/hive-v2.3-rfc/HIVE_V2_3_RUNTIME_AND_SANDBOX_SPEC.md"
+    assert_search_payload \
+        "$python_bin" \
+        "$examples_json" \
+        "example" \
+        "package:docs/recipes/sandbox-doctor.md"
+}
+
 run_uv_tool_smoke() {
     local uv_home="$TEMP_ROOT/uv-home"
     local uv_bin_dir="$uv_home/.local/bin"
@@ -59,6 +115,7 @@ run_uv_tool_smoke() {
     "$hive_bin" --path "$workspace" init --json >/dev/null
     "$hive_bin" --path "$workspace" doctor --json >/dev/null
     "$hive_bin" --path "$workspace" sandbox doctor --json >/dev/null
+    run_installed_search_smoke "$hive_bin" "$workspace"
 }
 
 run_pipx_smoke() {

--- a/tests/test_maintainer_surfaces.py
+++ b/tests/test_maintainer_surfaces.py
@@ -29,9 +29,10 @@ def test_v23_status_doc_tracks_release_gates_and_next_blocker():
     assert "Pi driver at acceptance bar | Deferred" in status_doc
     assert "full hybrid retrieval stack" in status_doc
     assert "the Daytona self-hosted proof now passed in a credentialed environment" in status_doc
-    assert "Release docs, demo, and acceptance alignment | Partial" in status_doc
-    assert "Finish the installed-package retrieval proof and the final release call" in status_doc
-    assert "finish the installed-package retrieval usefulness and release-demo validation pass" in status_doc
+    assert "Explainable retrieval, packaged corpus, and traces | Complete" in status_doc
+    assert "Release docs, demo, and acceptance alignment | Complete" in status_doc
+    assert "built-artifact release smoke path now proves installed-package `hive search`" in status_doc
+    assert "make the final v2.3 release call against the now-closed runtime" in status_doc
 
 
 def test_v23_acceptance_doc_tracks_scope_locked_remote_sandbox_truth():
@@ -59,6 +60,7 @@ def test_release_docs_require_scope_locked_v23_story_and_installed_search_proof(
     assert "Installed-package `hive search` is proven useful" in release_doc
     assert 'hive search "runtime contract" --scope api --limit 5 --json' in release_doc
     assert 'hive search "sandbox doctor" --scope examples --limit 5 --json' in release_doc
+    assert "built-artifact smoke script now proves installed-package" in release_doc
     assert "truthful v2.3 operator surface" in readme
     assert "Hive v2.3 assumes the operator mostly supervises" in operator_doc
     assert "If you want the latest unreleased checkout" in start_here

--- a/tests/test_release_tooling.py
+++ b/tests/test_release_tooling.py
@@ -308,6 +308,19 @@ def test_release_smoke_script_prefers_supported_python():
     assert "command -v python3 || command -v python" not in script
 
 
+def test_release_smoke_script_proves_installed_search_usefulness():
+    """Release install smoke should verify packaged search results, not only init/doctor."""
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "smoke_release_install.sh"
+    script = script_path.read_text(encoding="utf-8")
+
+    assert "run_installed_search_smoke()" in script
+    assert "assert_search_payload()" in script
+    assert '"$hive_bin" --path "$workspace" search "runtime contract" --scope api --limit 5 --json' in script
+    assert '"$hive_bin" --path "$workspace" search "sandbox doctor" --scope examples --limit 5 --json' in script
+    assert "package:docs/hive-v2.3-rfc/HIVE_V2_3_RUNTIME_AND_SANDBOX_SPEC.md" in script
+    assert "package:docs/recipes/sandbox-doctor.md" in script
+
+
 def test_release_workflow_requires_tag_and_homebrew_verification():
     """Tagged releases should be gated by both tag validation and Homebrew verification."""
     workflow_path = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "release.yml"


### PR DESCRIPTION
## Blocker Removed
Close the remaining installed-package retrieval usefulness gap by teaching the built-artifact release smoke path to prove packaged `hive search` works from a real install.

## Why This Slice Is Mergeable
This stays tightly scoped to the release/install surface. It extends the existing smoke script, updates the v2.3 ledger/release guide to reflect the new proof, and adds focused regression coverage.

## Validation
- bash -n scripts/smoke_release_install.sh
- uv run pytest tests/test_release_tooling.py tests/test_maintainer_surfaces.py tests/test_install_story.py -q
- make release-check
- Result: 40 passed; release-check passed end to end

## Review Discipline
I will treat Claude review as pending until there is a real review artifact on the latest PR head. Reactions alone do not count as completion, and I will watch the post-merge main CI run if this lands.