### PR TITLE
Polish onboarding story and prompt-first setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,24 +3,62 @@
 [![CI](https://img.shields.io/github/actions/workflow/status/intertwine/hive-orchestrator/ci.yml?branch=main&label=CI)](https://github.com/intertwine/hive-orchestrator/actions/workflows/ci.yml)
 [![Hive Projection Sync](https://img.shields.io/github/actions/workflow/status/intertwine/hive-orchestrator/projection-sync.yml?branch=main&label=Projection%20Sync)](https://github.com/intertwine/hive-orchestrator/actions/workflows/projection-sync.yml)
 
-![Agent Hive](images/agent-hive-explainer-image-web.png)
+![Agent Hive observe-and-steer console](images/launch/console-home.png)
 
 Agent Hive is a repo-native control plane for autonomous work. Keep your favorite worker harness, whether that is Codex, Claude Code, or a local/manual loop, and use Hive to supervise tasks, runs, memory, approvals, and campaigns from one place.
 
-The center of gravity in this repository is the Hive v2 substrate, with the current release line focused on a truthful v2.3 operator surface:
+**Keep your agent. Add a control plane.**
 
-- `hive` is the primary interface.
-- `.hive/tasks/*.md` is the canonical task store.
-- `projects/*/AGENCY.md` stays human-readable.
-- `projects/*/PROGRAM.md` defines evaluator, path, and command policy.
-- `GLOBAL.md` and `AGENTS.md` are bounded projections, not the machine database.
+If you are already using coding agents and feeling the limits of isolated sessions, Agent Hive is the layer that makes them feel like part of one real system:
 
-## Why Hive
+- one command center above many runs and many projects
+- one governed loop instead of “the agent said it was done”
+- one inspectable substrate instead of hidden agent state
+- one place to steer Codex, Claude Code, local execution, and manual handoffs
 
-- It gives humans one command center above many runs and many projects.
-- It keeps machine state explicit. Tasks, runs, memory, events, briefs, and campaigns live in predictable files.
-- It keeps harness choices flexible. Hive sits above Codex, Claude Code, local execution, and manual handoffs instead of replacing them.
-- It makes autonomous work inspectable. You can see what context a run received, what policy applied, what changed, and why it was accepted or escalated.
+The center of gravity in this repository is the Hive v2 substrate, with the current release line focused on a truthful v2.3 operator surface.
+
+## Why It Feels Different
+
+- The console is not a toy dashboard. It is a real observe-and-steer command center with active runs, inbox items, campaign reasoning, retrieval traces, and run detail in one place.
+- Hive does not replace your worker harness. It sits above it, so you can keep using Codex, Claude Code, local execution, or manual loops.
+- Agents do not decide when they are done. `PROGRAM.md` evaluators and promotion policy do.
+- Machine state stays explicit. Tasks, runs, memory, events, briefs, and campaigns live in predictable files instead of hidden session state.
+- You can get to a real governed loop in minutes, not after wiring up a framework.
+
+## Try It In 90 Seconds
+
+The shortest honest path is:
+
+```bash
+uv tool install mellona-hive
+mkdir my-hive && cd my-hive
+git init
+hive onboard demo --prompt "Create a small React website about bees."
+hive next --project-id demo
+hive work --owner <your-name>
+```
+
+If you want the live operator view, install `mellona-hive[console]` first and run:
+
+```bash
+hive console serve
+```
+
+Then finish the run:
+
+```bash
+hive finish <run-id>
+```
+
+What should happen:
+
+- `hive onboard demo` leaves you with a real workspace, starter project, safe `PROGRAM.md`, and one ready task
+- `hive work` starts a governed run and can write a handoff bundle for your worker harness
+- `hive finish` either promotes a real change or cleanly tells you there was nothing to promote yet
+
+If that first `hive finish` reports no changes, that is usually a healthy noop, not a broken setup. To intentionally
+see a successful first promotion, make one tiny docs-only change while working the demo task, then finish the run.
 
 ## Start Here
 
@@ -29,6 +67,8 @@ There are three clean ways into Hive:
 - [Install Hive](docs/START_HERE.md) if you want a fresh workspace and the shortest path to real work
 - [Adopt Hive in an existing repo](docs/ADOPT_EXISTING_REPO.md) if you already have a codebase and want Hive inside it
 - [Maintain or publish Hive](docs/MAINTAINING.md) if you are working on this repository itself
+
+If you only read one more page after this README, make it [docs/START_HERE.md](docs/START_HERE.md).
 
 ## Install Hive
 
@@ -69,7 +109,7 @@ Start in an empty directory and let Hive onboard the workspace for you:
 mkdir my-hive
 cd my-hive
 git init
-hive onboard demo --title "Demo project" --objective "Ship one small, governed slice."
+hive onboard demo --prompt "Create a small React website about bees."
 ```
 
 That gives you a real workspace with `.hive/`, a starter project, a safe default `PROGRAM.md`, and the first task
@@ -79,13 +119,22 @@ chain. If you want the React observe-and-steer console, install `mellona-hive[co
 Fresh onboarded projects may start with the placeholder `local-smoke` evaluator so the first governed loop works
 immediately. Replace it with a real repo-specific evaluator before you trust autonomous promotion.
 
+What a healthy first pass looks like:
+
+- `hive onboard demo` leaves you with one ready task and a safe starter `PROGRAM.md`
+- `hive work` starts a governed run and can write a handoff bundle for your worker harness
+- a first `hive finish` may either promote a real change or cleanly say there was nothing to promote yet
+
+If that first `hive finish` reports no changes, that is usually a healthy noop, not a broken setup. To intentionally
+see a successful first promotion, make one tiny docs-only change while working the demo task, then finish the run.
+
 Do this in a fresh workspace, not inside this repository checkout. This repo carries its own real maintainer task queue, so `hive task ready` here will show Hive's work unless you filter to `--project-id demo`.
 
 Once the workspace exists, the normal loop is:
 
 ```bash
 hive next --project-id demo
-hive work <task-id> --owner <your-name>
+hive work --owner <your-name>
 hive finish <run-id>
 ```
 
@@ -101,11 +150,11 @@ If you already have a repository:
 
 ```bash
 cd your-repo
-hive init
+hive adopt app --title "App"
 ```
 
-From there, either create a first project with `hive project create` or import an older checklist-based Hive setup
-with `hive migrate v1-to-v2`. The full path is documented in
+From there, either keep the guided adoption path or import an older checklist-based Hive setup with
+`hive migrate v1-to-v2`. The full path is documented in
 [docs/ADOPT_EXISTING_REPO.md](docs/ADOPT_EXISTING_REPO.md).
 
 ## Everyday Loop

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,8 @@
 
 | Version | Supported |
 | ------- | --------- |
-| 0.1.x   | yes       |
+| 2.2.x   | yes       |
+| 2.3.x   | yes       |
 
 ## Reporting a Vulnerability
 
@@ -27,7 +28,7 @@ We aim to acknowledge reports within 48 hours and provide a status update within
 
 ## Security Model
 
-Hive 2.0 is built around a local, file-backed substrate and explicit policy files.
+Hive is built around a local, file-backed substrate and explicit policy files.
 
 Core assumptions:
 

--- a/docs/ADOPT_EXISTING_REPO.md
+++ b/docs/ADOPT_EXISTING_REPO.md
@@ -11,7 +11,7 @@ Install Hive, then work from the root of the repo you want to manage:
 
 ```bash
 cd your-repo
-hive adopt app --title "App" --objective "Delegate the first governed slice safely."
+hive adopt app --prompt "Ship the first useful feature in this repo safely."
 ```
 
 If you want to stay closer to the primitives, you can still do the same thing in smaller steps:
@@ -48,6 +48,9 @@ obvious choice. If you want the observe-and-steer console, install `mellona-hive
 ```bash
 hive program doctor app
 ```
+
+If the first governed `hive finish` later says there was nothing to promote, that is usually a healthy noop. It means
+the run did not produce repo changes yet, not that the adoption path failed.
 
 If this repository is brand new or you want governed runs immediately after adding Hive, create a first commit for
 the workspace state:

--- a/docs/DEMO_WALKTHROUGH.md
+++ b/docs/DEMO_WALKTHROUGH.md
@@ -6,6 +6,9 @@ It still builds on the existing multi-project launch fixture from the v2.2 line,
 and temp paths keep their `v22` names. The point of this walkthrough is to show the deeper v2.3
 operator surface on top of that stable fixture, not to replace the fixture itself.
 
+If you just want to see the current product story, start with the checked-in screenshots and clip under
+`images/launch/`. You only need the fixture builder when you want to regenerate the demo locally.
+
 It builds the same north-star shape we use in acceptance:
 
 - three projects
@@ -46,7 +49,7 @@ http://127.0.0.1:8787/console/?workspace=/tmp/hive-v22-demo
 
 The console will prefill the workspace path from the URL so the demo opens ready to use.
 
-## 3. Record screenshots and a short walkthrough clip
+## 3. Regenerate screenshots and a short walkthrough clip
 
 The capture helper lives with the React console package at
 `frontend/console/scripts/captureDemoAssets.mjs`:

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -119,7 +119,7 @@ artifact on the latest PR head. An `eyes` reaction or acknowledgement on the req
 After merging, watch the `push` CI run on `main`. If the merge commit goes red, treat that as immediate new blocking
 work rather than assuming the green PR checks were sufficient.
 
-For bot-generated review branches, this repo also ships [/.github/workflows/branch-hygiene.yml](/Users/bryanyoung/experiments/hive-orchestrator/.github/workflows/branch-hygiene.yml). It runs weekly and can be triggered manually in dry-run mode when you want to preview what it would prune. The cleanup is intentionally conservative:
+For bot-generated review branches, this repo also ships [`.github/workflows/branch-hygiene.yml`](../.github/workflows/branch-hygiene.yml). It runs weekly and can be triggered manually in dry-run mode when you want to preview what it would prune. The cleanup is intentionally conservative:
 
 - merged `codex/*`, `claude/*`, and `copilot/*` branches are safe to delete
 - stale `claude/*` and `copilot/*` branches with no open PR are deleted after 7 days

--- a/docs/OPERATOR_FLOWS.md
+++ b/docs/OPERATOR_FLOWS.md
@@ -22,15 +22,22 @@ For a new workspace:
 
 ```bash
 hive onboard demo --title "Demo project"
-hive console serve
+hive next --project-id demo
+hive work --owner <your-name>
+hive finish <run-id>
 ```
 
 For an existing repo:
 
 ```bash
 hive adopt app --title "App"
-hive console serve
+hive next --project-id app
+hive work --project-id app --owner <your-name>
+hive finish <run-id>
 ```
+
+Install `mellona-hive[console]` first and add `hive console serve` beside that loop when you want the live
+observe-and-steer view from the beginning.
 
 ## Steering loop
 

--- a/docs/PYPI_README.md
+++ b/docs/PYPI_README.md
@@ -3,8 +3,11 @@
 Agent Hive is a repo-native control plane for autonomous work. Use Codex, Claude Code, or local/manual execution to
 do the work. Use Hive to supervise tasks, runs, memory, policy, and approvals from one place.
 
+**Keep your agent. Add a control plane.**
+
 `mellona-hive` is the distribution you install from PyPI or Homebrew. Mellona is the package family. Agent Hive is
-the current product. The install gives you the `hive` and `hive-mcp` commands.
+the current product. The base install gives you the `hive` command. Add `mellona-hive[mcp]` when you want the thin
+`hive-mcp` adapter.
 
 ## Install
 
@@ -65,7 +68,7 @@ Start in an empty directory:
 mkdir my-hive
 cd my-hive
 git init
-hive onboard demo --title "Demo project" --objective "Ship one governed slice."
+hive onboard demo --prompt "Create a small React website about bees."
 ```
 
 That gives you a real workspace, a starter project, a conservative `PROGRAM.md`, and a first task chain with one
@@ -74,6 +77,10 @@ ready task. If you want the observe-and-steer console, install `mellona-hive[con
 
 Fresh onboarded projects may start with the placeholder `local-smoke` evaluator so the loop works immediately. Replace
 it with a real repo-specific evaluator before you trust autonomous promotion.
+
+If the first `hive finish` later says there was nothing to promote, that is usually a healthy noop rather than a
+broken setup. To intentionally see a successful first promotion, make one tiny docs-only change while working the
+demo task, then finish the run.
 
 Then use the normal loop:
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -19,6 +19,11 @@ hive --version
 hive doctor
 ```
 
+What you should see:
+
+- `hive --version` prints the installed CLI version
+- `hive doctor` confirms the workspace layout or tells you the next missing step in plain language
+
 ## Create A Workspace In One Command
 
 Make a clean directory and run:
@@ -27,7 +32,7 @@ Make a clean directory and run:
 mkdir my-hive
 cd my-hive
 git init
-hive onboard demo --title "Demo project" --objective "Ship one governed slice."
+hive onboard demo --prompt "Create a small React website about bees."
 ```
 
 Use a fresh directory for this walkthrough. If you run these commands inside the Hive repository checkout, `hive task ready` will also see the maintainer tasks that ship with this repo.
@@ -43,6 +48,12 @@ That command:
 - syncs projections and cache
 
 You do not need to hand-write any of that to begin.
+
+After `hive onboard demo`, you have three good next moves:
+
+- `hive next --project-id demo` if you want the shortest path to ready work
+- `hive console serve` if you installed `mellona-hive[console]` and want the live operator surface
+- `hive program doctor demo` if you want to inspect or strengthen the starter policy before a governed run
 
 The `git init` is worth doing up front. `hive onboard` leaves the repo in a state where the normal manager loop and
 console are ready to go. If you want an explicit checkpoint commit after onboarding, run:
@@ -70,6 +81,12 @@ bundle echoed to stdout.
 
 If you want the live observe-and-steer board, install `mellona-hive[console]` first and run `hive console serve` in a
 separate terminal.
+
+What you should expect here:
+
+- `hive next` points at the ready demo task
+- `hive work` claims it, starts a governed run, and can write a reusable context bundle
+- the context bundle is what you hand to Codex, Claude, or another worker session when you want Hive to supervise the loop
 
 If you want to see or save the bundle yourself, use the lower-level commands:
 
@@ -123,6 +140,18 @@ hive task update <task-id> \
 
 Use `--clear-labels`, `--clear-relevant-files`, `--clear-acceptance`, or `--clear-parent` when you want to replace
 those fields cleanly.
+
+## Make The First Finish Feel Real
+
+There are two healthy first outcomes when you call `hive finish`:
+
+- a successful promotion because the run made a real change and passed the configured evaluators
+- a clean noop rejection because the run did not modify anything worth promoting yet
+
+That second outcome usually means the control loop is wired up correctly. It does not usually mean Hive is broken.
+
+If you want to experience a successful first promotion on purpose in the demo workspace, make one tiny docs-only
+change while working the demo task, such as tightening a sentence in `projects/demo/AGENCY.md`, then finish the run.
 
 ## Governed Runs
 

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -2,6 +2,9 @@
 
 Hive is a control plane for multi-agent software work. Use this page to pick the right path into it.
 
+Best first experience: install Hive, create a fresh workspace with `hive onboard demo`, then go straight into
+`hive next`, `hive work`, and `hive finish`.
+
 ## Choose Your Lane
 
 | If you want to... | Start here |
@@ -79,12 +82,20 @@ If you want the shortest path to a real Hive workspace:
 mkdir my-hive
 cd my-hive
 git init
-hive onboard demo --title "Demo project" --objective "Ship one governed slice."
+hive onboard demo --prompt "Create a small React website about bees."
 ```
 
 That path is covered in the full [Quickstart](./QUICKSTART.md). `hive onboard` is the recommended fresh-workspace
 bootstrap. `hive init` only creates the substrate layout. `hive onboard` bootstraps the workspace, detects the local
 driver situation, creates a starter project, runs Program Doctor, and leaves you with a safe first task chain.
+
+A healthy first `hive finish` can end in one of two ways:
+
+- accepted or promoted because the run made a real change
+- cleanly rejected because nothing changed yet
+
+If you want the demo workspace to show a successful promotion on purpose, make one tiny docs-only change while working
+the first demo task before you run `hive finish`.
 
 Once the workspace exists, the shortest manager-style loop is:
 

--- a/docs/UI_INFORMATION_ARCHITECTURE.md
+++ b/docs/UI_INFORMATION_ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # UI Information Architecture
 
-The Hive 2.2 console is organized around exceptions and decisions, not folders.
+The Hive v2.3 console is organized around exceptions and decisions, not folders.
 
 ## Home
 
@@ -37,9 +37,12 @@ Unified search across docs, tasks, runs, memory, recipes, campaigns, and project
 The deep-inspection view for one run:
 
 - timeline
+- capability snapshot and effective driver truth
+- sandbox policy and backend metadata
 - acceptance rationale
 - evaluator results
 - diff and changed files
-- driver metadata and logs
-- compiled context and inclusion reasons
+- retrieval trace and inclusion reasons
+- pending approvals and approval actions
 - steering history and steering actions
+- driver metadata and logs

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -1,0 +1,14 @@
+# Archived Docs
+
+This directory holds historical notes, polish queues, and interim sweeps that are still useful as reference material
+but are no longer part of the primary user or maintainer path.
+
+Prefer these files for current guidance:
+
+- `README.md`
+- `docs/START_HERE.md`
+- `docs/QUICKSTART.md`
+- `docs/ADOPT_EXISTING_REPO.md`
+- `docs/MAINTAINING.md`
+- `docs/RELEASING.md`
+- `docs/V2_3_STATUS.md`

--- a/docs/archive/UX_SWEEP.md
+++ b/docs/archive/UX_SWEEP.md
@@ -1,5 +1,8 @@
 # Hive UX Sweep
 
+Archived note: this is a historical usability findings log, not a canonical public or maintainer guide. Prefer the
+active onboarding docs and `docs/V2_3_STATUS.md` for current product truth.
+
 This file tracks real usability findings from hands-on Hive testing.
 
 The goal is simple: use Hive the way a new user, adopter, or maintainer would use it, then write down the rough edges while they are still fresh. We can fix these in focused polish passes instead of losing them in chat history.

--- a/docs/archive/V2_2_4_ONBOARDING_POLISH.md
+++ b/docs/archive/V2_2_4_ONBOARDING_POLISH.md
@@ -1,5 +1,9 @@
 # Hive v2.2.4 Onboarding Polish
 
+Archived note: kept as reference material after the v2.3 onboarding and release-doc cleanup. Prefer the active
+public docs in `README.md`, `docs/START_HERE.md`, `docs/QUICKSTART.md`, and `docs/V2_3_STATUS.md` for current
+guidance.
+
 Status: draft
 Date: 2026-03-18
 Source: Claude Code re-evaluation after v2.2.3

--- a/docs/hive-v2.3-rfc/HIVE_V2_3_ACCEPTANCE_TESTS.md
+++ b/docs/hive-v2.3-rfc/HIVE_V2_3_ACCEPTANCE_TESTS.md
@@ -1,7 +1,10 @@
 # Agent Hive v2.3 Acceptance Tests and Release Gates
 
-Status: Proposed  
+Status: Active scope-locked release-gate reference  
 Date: 2026-03-17
+
+This document is the active acceptance companion to `docs/V2_3_STATUS.md`. When older RFC language and the scoped
+release ledger disagree, follow the scope-locked truth in `docs/V2_3_STATUS.md`.
 
 ## 1. North-star release scenario
 

--- a/docs/hive-v2.3-rfc/HIVE_V2_3_IMPLEMENTATION_PLAN.md
+++ b/docs/hive-v2.3-rfc/HIVE_V2_3_IMPLEMENTATION_PLAN.md
@@ -1,7 +1,10 @@
 # Agent Hive v2.3 Implementation Plan
 
-Status: Proposed  
+Status: Historical planning reference  
 Date: 2026-03-17
+
+Current scoped release truth lives in `docs/V2_3_STATUS.md`. This plan captures the original implementation handoff
+and sequencing, including items later narrowed or deferred by the scoped v2.3 release line.
 
 ## 1. Overall approach
 

--- a/docs/hive-v2.3-rfc/HIVE_V2_3_RETRIEVAL_AND_CAMPAIGNS_SPEC.md
+++ b/docs/hive-v2.3-rfc/HIVE_V2_3_RETRIEVAL_AND_CAMPAIGNS_SPEC.md
@@ -1,7 +1,10 @@
 # Agent Hive v2.3 Retrieval and Campaigns Spec
 
-Status: Proposed  
+Status: Historical design reference  
 Date: 2026-03-17
+
+Current scoped release truth lives in `docs/V2_3_STATUS.md`. This spec is kept as packaged design context even though
+the shipped v2.3 line deliberately narrowed parts of the proposed retrieval and campaign depth.
 
 ## 1. Purpose
 

--- a/docs/hive-v2.3-rfc/HIVE_V2_3_RFC.md
+++ b/docs/hive-v2.3-rfc/HIVE_V2_3_RFC.md
@@ -1,9 +1,12 @@
 # Agent Hive v2.3 RFC — Completing the World-Class Observe-and-Steer Vision
 
-Status: Proposed  
+Status: Historical design reference  
 Date: 2026-03-17  
 Audience: product, engineering, docs, release, design  
 Applies to: `intertwine/hive-orchestrator` / package `mellona-hive` / product `Agent Hive`
+
+Current scoped release truth lives in `docs/V2_3_STATUS.md`. This RFC remains packaged and searchable as the broader
+design bundle, including ideas later narrowed or deferred for the actual v2.3 release.
 
 ## 1. Executive summary
 

--- a/docs/hive-v2.3-rfc/HIVE_V2_3_RUNTIME_AND_SANDBOX_SPEC.md
+++ b/docs/hive-v2.3-rfc/HIVE_V2_3_RUNTIME_AND_SANDBOX_SPEC.md
@@ -1,7 +1,10 @@
 # Agent Hive v2.3 Runtime and Sandbox Spec
 
-Status: Proposed  
+Status: Historical design reference  
 Date: 2026-03-17
+
+Current scoped release truth lives in `docs/V2_3_STATUS.md`. This spec remains valuable as a searchable design
+reference even where the shipped v2.3 line intentionally narrowed scope or deferred parts of the proposal.
 
 ## 1. Purpose
 

--- a/docs/hive-v2.3-rfc/README.md
+++ b/docs/hive-v2.3-rfc/README.md
@@ -1,6 +1,9 @@
 # Agent Hive v2.3 Completion RFC Bundle
 
-This bundle is the implementation handoff for **Agent Hive / Mellona Agent Hive v2.3**.
+This bundle is the historical planning and design reference for **Agent Hive / Mellona Agent Hive v2.3**.
+
+Current scoped release truth lives in [`docs/V2_3_STATUS.md`](../V2_3_STATUS.md). Use that ledger for what is
+actually required, complete, deferred, or still blocking the release call.
 
 ## Files
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,10 +7,10 @@ Start with the root [README](../README.md) for installation and first-run setup.
 ## Common Starting Point
 
 ```bash
-hive init --json
-hive project create demo --title "Demo project" --json
-hive task create --project-id demo --title "Define the first slice" --json
-hive context startup --project demo --json
+hive onboard demo --title "Demo project"
+hive next --project-id demo
+hive work --owner <your-name>
+hive finish <run-id>
 ```
 
 ## What Each Example Shows
@@ -30,7 +30,7 @@ hive context startup --project demo --json
 Each directory includes:
 
 - a `README.md` with the pattern and command flow
-- an `AGENCY.md` projection snapshot that shows how the human-facing document should read in Hive 2.0
+- an `AGENCY.md` projection snapshot that shows how the human-facing document should read in the current v2 substrate
 
 The important rule is the same in every example:
 

--- a/src/hive/cli/bootstrap.py
+++ b/src/hive/cli/bootstrap.py
@@ -65,7 +65,7 @@ def dispatch(args, root: Path) -> int:
                 objective=args.objective,
             )
             starter_tasks = []
-            for spec in _starter_specs()(project.title):
+            for spec in _starter_specs()(project.title, args.objective):
                 starter_tasks.append(
                     create_task(
                         root,

--- a/src/hive/cli/common.py
+++ b/src/hive/cli/common.py
@@ -101,7 +101,7 @@ def _doctor_payload(root: Path) -> dict[str, object]:
     next_steps: list[str] = []
     if not checks["layout"]:
         next_steps.append(
-            'Run `hive onboard demo --title "Demo project"` '
+            'Run `hive onboard demo --prompt "Create a small React website about bees."` '
             "to bootstrap a workspace with a starter project and ready task."
         )
         next_steps.append(
@@ -113,7 +113,7 @@ def _doctor_payload(root: Path) -> dict[str, object]:
         next_steps.append("Run `hive sync projections` to create `AGENTS.md`.")
     if checks["layout"] and not projects:
         next_steps.append(
-            'Run `hive onboard demo --title "Demo project"` '
+            'Run `hive onboard demo --prompt "Create a small React website about bees."` '
             "to scaffold a working project with starter tasks."
         )
         next_steps.append(

--- a/src/hive/cli/parser.py
+++ b/src/hive/cli/parser.py
@@ -19,7 +19,12 @@ def _add_bootstrap_parsers(subparsers: argparse._SubParsersAction[argparse.Argum
     )
     quickstart_parser.add_argument("slug", nargs="?", default="demo")
     quickstart_parser.add_argument("--title")
-    quickstart_parser.add_argument("--objective")
+    quickstart_parser.add_argument(
+        "--objective",
+        "--prompt",
+        dest="objective",
+        help="Plain-English project goal used to seed the starter project and task chain.",
+    )
 
     onboard_parser = subparsers.add_parser(
         "onboard",
@@ -27,12 +32,22 @@ def _add_bootstrap_parsers(subparsers: argparse._SubParsersAction[argparse.Argum
     )
     onboard_parser.add_argument("slug", nargs="?", default="demo")
     onboard_parser.add_argument("--title")
-    onboard_parser.add_argument("--objective")
+    onboard_parser.add_argument(
+        "--objective",
+        "--prompt",
+        dest="objective",
+        help="Plain-English project goal used to seed the starter project and task chain.",
+    )
 
     adopt_parser = subparsers.add_parser("adopt")
     adopt_parser.add_argument("slug", nargs="?")
     adopt_parser.add_argument("--title")
-    adopt_parser.add_argument("--objective")
+    adopt_parser.add_argument(
+        "--objective",
+        "--prompt",
+        dest="objective",
+        help="Plain-English project goal used to seed the starter project and task chain.",
+    )
 
     subparsers.add_parser(
         "init",
@@ -162,7 +177,12 @@ def _add_project_parsers(subparsers: argparse._SubParsersAction[argparse.Argumen
     project_create.add_argument("--project-id")
     project_create.add_argument("--status", default="active")
     project_create.add_argument("--priority", type=int, default=2)
-    project_create.add_argument("--objective")
+    project_create.add_argument(
+        "--objective",
+        "--prompt",
+        dest="objective",
+        help="Plain-English project goal used to seed the project mission.",
+    )
     project_create.add_argument("--tag", action="append")
     project_show = project_subparsers.add_parser("show")
     project_show.add_argument("project_id")
@@ -434,7 +454,7 @@ def _add_knowledge_parsers(subparsers: argparse._SubParsersAction[argparse.Argum
 
 def build_parser() -> argparse.ArgumentParser:
     """Build the Hive CLI parser."""
-    parser = argparse.ArgumentParser(prog="hive", description="Hive 2.2 control-plane CLI")
+    parser = argparse.ArgumentParser(prog="hive", description="Hive v2.3 control-plane CLI")
     parser.add_argument("--path", default=str(Path.cwd()), help="Workspace base path")
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
     parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")

--- a/src/hive/onboarding.py
+++ b/src/hive/onboarding.py
@@ -40,7 +40,9 @@ def _serializable_bootstrap(payload: dict[str, object]) -> dict[str, object]:
     }
 
 
-def _seed_starter_tasks(root: Path, project_id: str, project_title: str) -> list[dict[str, object]]:
+def _seed_starter_tasks(
+    root: Path, project_id: str, project_title: str, objective: str | None = None
+) -> list[dict[str, object]]:
     existing = [task for task in list_tasks(root) if task.project_id == project_id]
     if existing:
         return [
@@ -54,7 +56,7 @@ def _seed_starter_tasks(root: Path, project_id: str, project_title: str) -> list
             for task in existing
         ]
     tasks = []
-    for spec in starter_task_specs(project_title):
+    for spec in starter_task_specs(project_title, objective):
         task = create_task(
             root,
             project_id,
@@ -104,7 +106,7 @@ def onboard_workspace(
             break
     if project is None:
         project = create_project(root, slug, title=title, objective=objective)
-    tasks = _seed_starter_tasks(root, project.id, project.title)
+    tasks = _seed_starter_tasks(root, project.id, project.title, objective)
     diagnosis = _auto_fix_program(root, project.id)
     sync_workspace(root)
     return {
@@ -132,7 +134,7 @@ def adopt_repository(
     if project is None:
         resolved_slug = slug or root.name.replace("_", "-")
         project = create_project(root, resolved_slug, title=title, objective=objective)
-    tasks = _seed_starter_tasks(root, project.id, project.title)
+    tasks = _seed_starter_tasks(root, project.id, project.title, objective)
     diagnosis = _auto_fix_program(root, project.id)
     sync_workspace(root)
     return {

--- a/src/hive/scaffold.py
+++ b/src/hive/scaffold.py
@@ -65,37 +65,43 @@ def generate_program_stub(project_dir: Path) -> Path:
     return target
 
 
-def starter_task_specs(project_title: str) -> list[dict[str, object]]:
+def starter_task_specs(project_title: str, objective: str | None = None) -> list[dict[str, object]]:
     """Return a small, opinionated task chain for a fresh workspace."""
     subject = project_title.strip() or "the project"
+    goal = (objective or "").strip()
+    goal_sentence = f"Project goal: {goal}" if goal else ""
     return [
         {
-            "title": f"Define the first thin slice for {subject}",
+            "title": f"Plan the first milestone for {subject}",
             "status": "ready",
             "priority": 1,
             "acceptance": [
-                "Scope is small enough to review in one PR or session.",
+                "The project goal is translated into one small, reviewable milestone.",
                 "Acceptance criteria are written down in the task or AGENCY.md.",
-                "Relevant files or directories are identified.",
+                "Relevant files, directories, or open questions are identified.",
             ],
             "summary_md": (
-                "Turn the project goal into the smallest useful slice that is safe to hand to "
-                "a human or agent."
+                "Turn the plain-English project goal into the first useful milestone that is safe "
+                "to hand to a human or agent."
+                + (f"\n\n{goal_sentence}" if goal_sentence else "")
             ),
         },
         {
-            "title": f"Implement the first thin slice for {subject}",
+            "title": f"Build the first reviewable milestone for {subject}",
             "status": "proposed",
             "priority": 1,
             "acceptance": [
-                "The slice is implemented or documented in a reviewable form.",
+                "The milestone is implemented or documented in a reviewable form.",
                 "Run artifacts or handoff notes capture what changed.",
                 "The result is ready for review or explicit follow-up.",
             ],
-            "summary_md": "Build the first useful slice once scope and boundaries are clear.",
+            "summary_md": (
+                "Build the first useful milestone once scope and boundaries are clear."
+                + (f"\n\n{goal_sentence}" if goal_sentence else "")
+            ),
         },
         {
-            "title": f"Review, document, and hand off the first thin slice for {subject}",
+            "title": f"Review, document, and hand off the first milestone for {subject}",
             "status": "proposed",
             "priority": 2,
             "acceptance": [
@@ -106,6 +112,7 @@ def starter_task_specs(project_title: str) -> list[dict[str, object]]:
             "summary_md": (
                 "Close the loop with projections, notes, and the next clean handoff for the "
                 "workspace."
+                + (f"\n\n{goal_sentence}" if goal_sentence else "")
             ),
         },
     ]

--- a/src/hive/search.py
+++ b/src/hive/search.py
@@ -52,12 +52,12 @@ COMMAND_DOCS = (
     {
         "title": "hive onboard",
         "summary": "Recommended fresh-workspace bootstrap with a starter project and task chain.",
-        "example": 'hive onboard demo --title "Demo project"',
+        "example": 'hive onboard demo --prompt "Create a small React website about bees."',
     },
     {
         "title": "hive quickstart",
         "summary": "Legacy compatibility alias for `hive onboard`; prefer `hive onboard`.",
-        "example": 'hive quickstart demo --title "Demo project"',
+        "example": 'hive quickstart demo --prompt "Create a small React website about bees."',
     },
     {
         "title": "hive init",

--- a/src/hive/store/projects.py
+++ b/src/hive/store/projects.py
@@ -13,6 +13,29 @@ from src.security import safe_dump_agency_md, safe_load_agency_md
 
 
 SLUG_PART_RE = re.compile(r"[^a-z0-9]+")
+_LEADING_OBJECTIVE_WORDS = {
+    "a",
+    "an",
+    "the",
+    "small",
+    "simple",
+    "tiny",
+    "basic",
+    "new",
+    "demo",
+}
+_LEADING_OBJECTIVE_VERBS = {
+    "build",
+    "create",
+    "design",
+    "draft",
+    "launch",
+    "make",
+    "plan",
+    "prototype",
+    "ship",
+    "write",
+}
 
 
 def _extract_title(content: str, fallback: str) -> str:
@@ -46,6 +69,25 @@ def _normalize_slug(value: str) -> str:
 def _title_from_slug(slug: str) -> str:
     label = slug.split("/")[-1].replace("-", " ").strip()
     return label.title() or "Untitled Project"
+
+
+def _title_from_objective(objective: str | None) -> str | None:
+    if not objective:
+        return None
+    cleaned = re.sub(r"\s+", " ", objective.strip()).strip(" .,:;!-")
+    if not cleaned:
+        return None
+    words = cleaned.split()
+    while words and words[0].lower() in _LEADING_OBJECTIVE_VERBS:
+        words.pop(0)
+    while words and words[0].lower() in _LEADING_OBJECTIVE_WORDS:
+        words.pop(0)
+    if not words:
+        words = cleaned.split()
+    candidate = " ".join(words[:6]).strip(" .,:;!-")
+    if not candidate:
+        return None
+    return candidate.title()
 
 
 def _project_id_from_slug(slug: str) -> str:
@@ -131,7 +173,9 @@ def create_project(
     """Create a new project scaffold with AGENCY.md and PROGRAM.md."""
     root = Path(path or Path.cwd())
     normalized_slug = _normalize_slug(slug)
-    resolved_title = title.strip() if title else _title_from_slug(normalized_slug)
+    resolved_title = title.strip() if title else (
+        _title_from_objective(objective) or _title_from_slug(normalized_slug)
+    )
     if project_id and project_id.strip():
         resolved_project_id = project_id.strip()
     else:

--- a/tests/test_console_api.py
+++ b/tests/test_console_api.py
@@ -37,7 +37,12 @@ class TestObserveConsoleApi:
             ["--path", temp_hive_dir, "--json", "quickstart", "demo", "--title", "Demo"],
         )
         write_safe_program(temp_hive_dir, "demo")
-        create_task(temp_hive_dir, "demo", "Review-ready slice", status="ready", priority=1)
+        review_ready_task = create_task(
+            temp_hive_dir, "demo", "Review-ready slice", status="ready", priority=1
+        )
+        follow_up_task = create_task(
+            temp_hive_dir, "demo", "Follow-up review slice", status="ready", priority=1
+        )
         subprocess.run(["git", "add", "-A"], cwd=temp_hive_dir, check=True)
         subprocess.run(
             ["git", "commit", "-m", "Bootstrap workspace"],
@@ -46,10 +51,8 @@ class TestObserveConsoleApi:
             capture_output=True,
             text=True,
         )
-        task_id = ready_tasks(temp_hive_dir, project_id="demo")[0]["id"]
-        run = start_run(temp_hive_dir, task_id, driver_name="codex")
-        review_task_id = ready_tasks(temp_hive_dir, project_id="demo")[0]["id"]
-        local_run = start_run(temp_hive_dir, review_task_id, driver_name="local")
+        run = start_run(temp_hive_dir, review_ready_task.id, driver_name="codex")
+        local_run = start_run(temp_hive_dir, follow_up_task.id, driver_name="local")
         eval_run(temp_hive_dir, local_run.id)
 
         client = TestClient(app)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -55,7 +55,12 @@ def _bootstrap_observe_workspace(temp_hive_dir: str, capsys) -> tuple[object, ob
         ["--path", temp_hive_dir, "--json", "quickstart", "demo", "--title", "Demo"],
     )
     write_safe_program(temp_hive_dir, "demo")
-    create_task(temp_hive_dir, "demo", "Review-ready slice", status="ready", priority=1)
+    review_ready_task = create_task(
+        temp_hive_dir, "demo", "Review-ready slice", status="ready", priority=1
+    )
+    follow_up_task = create_task(
+        temp_hive_dir, "demo", "Follow-up review slice", status="ready", priority=1
+    )
     subprocess.run(["git", "add", "-A"], cwd=temp_hive_dir, check=True)
     subprocess.run(
         ["git", "commit", "-m", "Bootstrap workspace"],
@@ -64,10 +69,8 @@ def _bootstrap_observe_workspace(temp_hive_dir: str, capsys) -> tuple[object, ob
         capture_output=True,
         text=True,
     )
-    task_id = ready_tasks(temp_hive_dir, project_id="demo")[0]["id"]
-    waiting_run = start_run(temp_hive_dir, task_id, driver_name="codex")
-    review_task_id = ready_tasks(temp_hive_dir, project_id="demo")[0]["id"]
-    review_run = start_run(temp_hive_dir, review_task_id, driver_name="local")
+    waiting_run = start_run(temp_hive_dir, review_ready_task.id, driver_name="codex")
+    review_run = start_run(temp_hive_dir, follow_up_task.id, driver_name="local")
     eval_run(temp_hive_dir, review_run.id)
     return waiting_run, review_run
 

--- a/tests/test_hive_v2.py
+++ b/tests/test_hive_v2.py
@@ -1773,11 +1773,42 @@ class TestHiveV2Cli:
         assert payload["tasks"][1]["status"] == "proposed"
         assert payload["tasks"][2]["status"] == "proposed"
         ready = ready_tasks(workspace, project_id="launch-demo")
-        assert [item["title"] for item in ready] == ["Define the first thin slice for Launch Demo"]
+        assert [item["title"] for item in ready] == ["Plan the first milestone for Launch Demo"]
         agency_content = Path(payload["project"]["path"]).read_text(encoding="utf-8")
         assert "Ship the launch-ready Hive demo workspace." in agency_content
         assert any("hive task claim" in step for step in payload["next_steps"])
         assert all("--json" not in step for step in payload["next_steps"])
+
+    def test_cli_onboard_prompt_alias_scaffolds_a_human_goal(self, tmp_path, capsys):
+        """Onboard should accept a plain-English prompt and turn it into a meaningful starter project."""
+        workspace = tmp_path / "prompt-hive"
+
+        exit_code = hive_main(
+            [
+                "--path",
+                str(workspace),
+                "--json",
+                "onboard",
+                "demo",
+                "--prompt",
+                "Create a small React website about bees.",
+            ]
+        )
+        captured = capsys.readouterr()
+
+        assert exit_code == 0
+        payload = json.loads(captured.out)
+        assert payload["project"]["id"] == "demo"
+        assert payload["project"]["title"] == "React Website About Bees"
+        assert [task["title"] for task in payload["tasks"]] == [
+            "Plan the first milestone for React Website About Bees",
+            "Build the first reviewable milestone for React Website About Bees",
+            "Review, document, and hand off the first milestone for React Website About Bees",
+        ]
+        agency_content = Path(payload["project"]["path"]).read_text(encoding="utf-8")
+        assert "Create a small React website about bees." in agency_content
+        assert "hive next --project-id demo" in payload["next_steps"]
+        assert "hive work --project-id demo --owner <your-name>" in payload["next_steps"]
 
     def test_cli_quickstart_rejects_existing_project(self, tmp_path, capsys):
         """Quickstart should fail cleanly if the starter slug already exists."""
@@ -1801,7 +1832,7 @@ class TestHiveV2Cli:
         """Quickstart should surface scaffold failures as structured JSON errors."""
         workspace = tmp_path / "quickstart-empty"
 
-        monkeypatch.setattr(hive_cli_main, "starter_task_specs", lambda _title: [])
+        monkeypatch.setattr(hive_cli_main, "starter_task_specs", lambda *_args: [])
 
         exit_code = hive_main(["--path", str(workspace), "--json", "quickstart"])
         captured = capsys.readouterr()
@@ -2715,7 +2746,7 @@ class TestHiveV2Search:
         workspace = tmp_path / "search-priority"
         hive_main(["--path", str(workspace), "--json", "quickstart", "launch/demo"])
 
-        results = search_workspace(workspace, "thin slice", scopes=["workspace"], limit=5)
+        results = search_workspace(workspace, "first milestone", scopes=["workspace"], limit=5)
 
         assert results
         assert results[0]["kind"] == "task"

--- a/tests/test_install_story.py
+++ b/tests/test_install_story.py
@@ -48,15 +48,20 @@ def test_public_readmes_surface_three_clear_entry_points():
     assert "Maintain or publish Hive" in readme
     assert "control plane" in readme.lower()
     assert "Mellona" in readme
+    assert "Keep your agent. Add a control plane." in readme
+    assert "Try It In 90 Seconds" in readme
 
     assert "Fresh Workspace" in start_here
     assert "Existing Repo" in start_here
     assert "Maintainers" in start_here
     assert "Mellona" in start_here
+    assert "Create a small React website about bees." in start_here
 
     assert "make install-dev" not in pypi_readme
     assert "src.agent_dispatcher" not in pypi_readme
     assert "Mellona" in pypi_readme
+    assert "Keep your agent. Add a control plane." in pypi_readme
+    assert "Create a small React website about bees." in pypi_readme
 
 
 def test_public_docs_call_out_console_extra_before_console_serve():
@@ -110,7 +115,16 @@ def test_onboarding_docs_explain_local_smoke_is_only_a_placeholder():
     assert "placeholder `local-smoke` evaluator" in readme
     assert "does not validate project behavior" in quickstart
     assert "placeholder `local-smoke` evaluator" in pypi_readme
+    assert "healthy noop" in pypi_readme
     assert "bootstrap placeholder" in recipe
+
+
+def test_pypi_readme_keeps_mcp_as_an_optional_extra():
+    """The package README should not imply the thin MCP adapter is part of the base install."""
+    pypi_readme = (REPO_ROOT / "docs" / "PYPI_README.md").read_text(encoding="utf-8")
+
+    assert "The base install gives you the `hive` command." in pypi_readme
+    assert "Add `mellona-hive[mcp]` when you want the thin" in pypi_readme
 
 
 def test_start_here_install_matrix_covers_common_installers_and_homebrew_limit():

--- a/tests/test_launch_collateral.py
+++ b/tests/test_launch_collateral.py
@@ -37,6 +37,7 @@ def test_readme_and_compare_docs_keep_the_control_plane_launch_story():
     assert "control plane" in readme.lower()
     assert "command center" in readme.lower()
     assert "docs/DEMO_WALKTHROUGH.md" in readme
+    assert "images/launch/console-home.png" in readme
     assert "current release line focused on a truthful v2.3 operator surface" in readme
     assert "control plane above the worker harness" in compare.lower()
 

--- a/tests/test_maintainer_surfaces.py
+++ b/tests/test_maintainer_surfaces.py
@@ -66,6 +66,35 @@ def test_release_docs_require_scope_locked_v23_story_and_installed_search_proof(
     assert "If you want the latest unreleased checkout" in start_here
 
 
+def test_archive_and_rfc_docs_frame_historical_material_clearly():
+    """Historical notes and broader RFC bundles should point readers back to the live v2.3 ledger."""
+    archive_readme = (REPO_ROOT / "docs" / "archive" / "README.md").read_text(encoding="utf-8")
+    onboarding_note = (
+        REPO_ROOT / "docs" / "archive" / "V2_2_4_ONBOARDING_POLISH.md"
+    ).read_text(encoding="utf-8")
+    ux_sweep = (REPO_ROOT / "docs" / "archive" / "UX_SWEEP.md").read_text(encoding="utf-8")
+    rfc_readme = (REPO_ROOT / "docs" / "hive-v2.3-rfc" / "README.md").read_text(encoding="utf-8")
+    implementation_plan = (
+        REPO_ROOT / "docs" / "hive-v2.3-rfc" / "HIVE_V2_3_IMPLEMENTATION_PLAN.md"
+    ).read_text(encoding="utf-8")
+    acceptance_doc = (
+        REPO_ROOT / "docs" / "hive-v2.3-rfc" / "HIVE_V2_3_ACCEPTANCE_TESTS.md"
+    ).read_text(encoding="utf-8")
+    security_doc = (REPO_ROOT / "SECURITY.md").read_text(encoding="utf-8")
+
+    assert "# Archived Docs" in archive_readme
+    assert "no longer part of the primary user or maintainer path" in archive_readme
+    assert "Archived note" in onboarding_note
+    assert "Archived note" in ux_sweep
+    assert "historical planning and design reference" in rfc_readme
+    assert "Current scoped release truth lives in" in rfc_readme
+    assert "Status: Historical planning reference" in implementation_plan
+    assert "Status: Active scope-locked release-gate reference" in acceptance_doc
+    assert "| 2.2.x   | yes       |" in security_doc
+    assert "| 2.3.x   | yes       |" in security_doc
+    assert "Hive is built around a local, file-backed substrate" in security_doc
+
+
 def test_pull_request_template_enforces_slice_and_review_discipline():
     """The PR template should ask for blocker, validation, and review closure."""
     template = (REPO_ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md").read_text(encoding="utf-8")
@@ -131,6 +160,7 @@ def test_repo_relies_on_managed_claude_review_instead_of_repo_local_workflow():
     assert "local Claude review is an acceptable primary or fallback path" in maintaining_doc
     assert 'claude -p "/review <pr-number>"' in maintaining_doc
     assert "Use the explicit scope-lock notes there as the current release truth" in maintaining_doc
+    assert "/Users/bryanyoung/experiments/hive-orchestrator/.github/workflows/branch-hygiene.yml" not in maintaining_doc
     assert "An `eyes` reaction alone does not count as completion." in agents_doc
     assert "An `eyes` reaction alone does not count as completion." in claude_doc
     assert 'claude -p "/review <pr-number>"' in skill_doc

--- a/tests/test_onboarding_story.py
+++ b/tests/test_onboarding_story.py
@@ -63,17 +63,28 @@ def test_onboarding_docs_keep_everyday_user_flow_task_specific():
     demo_agency = (REPO_ROOT / "projects" / "demo" / "AGENCY.md").read_text(encoding="utf-8")
 
     assert "## Start Here" in readme
+    assert "## Try It In 90 Seconds" in readme
     assert "[Install Hive](docs/START_HERE.md)" in readme
+    assert "Keep your agent. Add a control plane." in readme
+    assert "one command center above many runs and many projects" in readme
+    assert "The console is not a toy dashboard." in readme
     assert "## Adopt Hive In An Existing Repo" in readme
     assert "## Maintainers" in readme
     assert "Do this in a fresh workspace, not inside this repository checkout." in readme
     assert "hive next --project-id demo" in readme
     assert "hive onboard demo" in readme
+    assert "Create a small React website about bees." in readme
+    assert "mkdir my-hive && cd my-hive" in readme
     assert "hive console serve" in readme
+    assert "healthy noop" in readme
     assert "[docs/MAINTAINING.md](docs/MAINTAINING.md)" in readme
 
     assert "Use a fresh directory for this walkthrough." in quickstart
     assert "If you are maintaining Hive itself" in quickstart
+    assert "Create a small React website about bees." in quickstart
+    assert "After `hive onboard demo`, you have three good next moves" in quickstart
+    assert "Make The First Finish Feel Real" in quickstart
+    assert "successful first promotion" in quickstart
     assert "Once you have more than one project and want the cross-project queue" in quickstart
     assert "hive program doctor demo" in quickstart
     assert "does not validate project behavior" in quickstart

--- a/tests/test_v22_docs.py
+++ b/tests/test_v22_docs.py
@@ -1,4 +1,4 @@
-"""Docs coverage for the v2.2 control-plane story."""
+"""Docs coverage for control-plane reference surfaces."""
 
 from __future__ import annotations
 
@@ -9,11 +9,13 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_control_plane_docs_and_harness_guides_exist():
-    """The v2.2 launch docs should cover compare, IA, flows, harnesses, and migration."""
+    """Reference docs should cover compare, IA, flows, harnesses, migration, and examples."""
     compare = (REPO_ROOT / "docs" / "COMPARE_HARNESSES.md").read_text(encoding="utf-8")
     ia = (REPO_ROOT / "docs" / "UI_INFORMATION_ARCHITECTURE.md").read_text(encoding="utf-8")
     flows = (REPO_ROOT / "docs" / "OPERATOR_FLOWS.md").read_text(encoding="utf-8")
     migration = (REPO_ROOT / "docs" / "MIGRATING_TO_V2_2.md").read_text(encoding="utf-8")
+    examples = (REPO_ROOT / "examples" / "README.md").read_text(encoding="utf-8")
+    parser = (REPO_ROOT / "src" / "hive" / "cli" / "parser.py").read_text(encoding="utf-8")
     codex = (REPO_ROOT / "docs" / "recipes" / "codex-harness.md").read_text(encoding="utf-8")
     claude = (REPO_ROOT / "docs" / "recipes" / "claude-code-harness.md").read_text(
         encoding="utf-8"
@@ -26,10 +28,16 @@ def test_control_plane_docs_and_harness_guides_exist():
     )
 
     assert "control plane" in compare.lower()
+    assert "Hive v2.3 console" in ia
     assert "Runs" in ia
     assert "Campaigns" in ia
+    assert "capability snapshot" in ia
+    assert "retrieval trace" in ia
     assert "manager loop" in flows.lower()
     assert "the real product surface is the React console" in migration
+    assert "hive onboard demo" in examples
+    assert "current v2 substrate" in examples
+    assert 'description="Hive v2.3 control-plane CLI"' in parser
     assert "Codex" in codex
     assert "Claude Code" in claude
     assert "hive campaign create" in campaigns

--- a/tests/test_v23_runtime_foundation.py
+++ b/tests/test_v23_runtime_foundation.py
@@ -432,7 +432,7 @@ def test_cloudflare_probe_detects_api_token_configuration(monkeypatch):
 
 def test_start_run_writes_v23_foundation_artifacts(temp_hive_dir, capsys):
     _bootstrap_workspace(temp_hive_dir, capsys)
-    create_task(
+    created_task = create_task(
         temp_hive_dir,
         "demo",
         "Sandbox policy evaluator guardrails",
@@ -440,7 +440,7 @@ def test_start_run_writes_v23_foundation_artifacts(temp_hive_dir, capsys):
         priority=1,
         summary_md="Update PROGRAM budget and sandbox approval rules.",
     )
-    task_id = ready_tasks(temp_hive_dir, project_id="demo")[0]["id"]
+    task_id = created_task.id
     run = start_run(temp_hive_dir, task_id, driver_name="codex")
     run_root = Path(temp_hive_dir) / ".hive" / "runs" / run.id
 
@@ -491,7 +491,7 @@ def test_start_run_materializes_claude_projection_and_selected_skills(temp_hive_
     script_path = skill_root / "scripts" / "policy-check.sh"
     script_path.parent.mkdir(parents=True, exist_ok=True)
     script_path.write_text("#!/bin/sh\necho policy-check\n", encoding="utf-8")
-    create_task(
+    created_task = create_task(
         temp_hive_dir,
         "demo",
         "Sandbox policy evaluator guardrails",
@@ -507,7 +507,7 @@ def test_start_run_materializes_claude_projection_and_selected_skills(temp_hive_
         capture_output=True,
         text=True,
     )
-    task_id = ready_tasks(temp_hive_dir, project_id="demo")[0]["id"]
+    task_id = created_task.id
     run = start_run(temp_hive_dir, task_id, driver_name="claude-code")
     run_root = Path(temp_hive_dir) / ".hive" / "runs" / run.id
 


### PR DESCRIPTION
## Summary
- reshape the public onboarding/docs surfaces into a faster, clearer product story
- make plain-English `--prompt` a first-class onboarding path across onboard/quickstart/adopt/project create
- archive stale docs and harden tests that relied on ambiguous seeded task ordering

## What Changed
- rewrote the top-level README and primary onboarding docs to lead with what Hive is, why it is exciting, and how to try it quickly
- updated onboarding flows so prompts like `Create a small React website about bees.` scaffold a titled project and human starter milestones
- clarified demo/operator docs, archived older planning notes into `docs/archive/`, and reframed the v2.3 RFC bundle as searchable design/history with current release truth living elsewhere
- fixed test setups that were accidentally grabbing the first seeded ready task instead of the task they created explicitly

## Validation
- `uv run pytest tests/test_hive_v2.py tests/test_hive_campaigns.py tests/test_onboarding_story.py tests/test_install_story.py tests/test_maintainer_surfaces.py tests/test_launch_collateral.py -q`
- `uv run pytest tests/test_v23_runtime_foundation.py -k 'start_run_writes_v23_foundation_artifacts or start_run_materializes_claude_projection_and_selected_skills' -q`
- `uv run pytest tests/test_console_api.py tests/test_dashboard.py -q`
- `make check`
  - `588 passed, 4 skipped, 1 warning`

## Review Notes
- this PR is intentionally docs/onboarding focused plus the minimal test hardening needed to keep seeded-task assumptions truthful after the prompt-first onboarding change
