### PR TITLE
Prepare the v2.3.0 release

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -55,6 +55,15 @@ checks are closed:
 1. README, demo walkthrough, compare-harness, and operator docs match the shipped observe-and-steer story.
 2. Installed-package `hive search` is proven useful from a throwaway install, not only from a source checkout.
 
+For the actual v2.3.0 release cut from this repo state, the expected version bump is:
+
+```bash
+make bump-version BUMP=minor
+uv lock
+```
+
+Update [docs/V2_3_STATUS.md](/docs/V2_3_STATUS.md) at the same time so the ledger points at tag-and-publish as the only remaining blocker before you cut the tag.
+
 ## Cut A Release
 
 Bump the version:
@@ -147,7 +156,7 @@ Also check a real first-run flow in a clean workspace:
 workspace_dir=$(mktemp -d)
 cd "$workspace_dir"
 
-hive onboard demo --title "Demo project"
+hive onboard demo --prompt "Create a small React website about bees."
 hive doctor --json
 hive task ready --project-id demo --json
 ```

--- a/docs/V2_3_STATUS.md
+++ b/docs/V2_3_STATUS.md
@@ -1,7 +1,7 @@
 # Hive v2.3 Status
 
-Status: active
-Last updated: 2026-03-19
+Status: ready for release
+Last updated: 2026-03-20
 Purpose: compact execution ledger for the current v2.3 release line
 
 This file is the maintainer-facing status ledger for v2.3. Update it when a v2.3
@@ -37,7 +37,7 @@ The following items are explicitly deferred from blocking the v2.3 release:
 | Campaign candidate and decision artifacts | Complete | `candidate-set.json`, `decision.json`, `src/hive/control/campaigns.py`, `frontend/console/src/routes/CampaignDetailPage.tsx`, `frontend/console/src/test/observeConsole.smoke.test.tsx` | Final release/demo validation only |
 | Observe-and-steer console at RFC depth | Complete | `frontend/console/src/routes/RunDetailPage.tsx`, `frontend/console/src/routes/InboxPage.tsx`, `frontend/console/src/routes/CampaignDetailPage.tsx`, `tests/test_console_frontend_story.py`, `frontend/console/src/test/observeConsole.smoke.test.tsx` | Final release/demo validation only |
 | Pi driver at acceptance bar | Deferred | `src/hive/drivers/pi.py`, `docs/hive-v2.3-rfc/HIVE_V2_3_RUNTIME_AND_SANDBOX_SPEC.md` | Keep staged truthfulness intact and carry full RPC depth to the next release line |
-| Release docs, demo, and acceptance alignment | Complete | `README.md`, `docs/DEMO_WALKTHROUGH.md`, `docs/OPERATOR_FLOWS.md`, `docs/START_HERE.md`, `docs/RELEASING.md`, `docs/hive-v2.3-rfc/HIVE_V2_3_ACCEPTANCE_TESTS.md`, `tests/test_launch_collateral.py`, `tests/test_maintainer_surfaces.py`, `scripts/smoke_release_install.sh`, `tests/test_release_tooling.py` | Final release/demo validation only |
+| Release docs, demo, and acceptance alignment | Complete | `#148`, `README.md`, `docs/DEMO_WALKTHROUGH.md`, `docs/OPERATOR_FLOWS.md`, `docs/START_HERE.md`, `docs/RELEASING.md`, `docs/hive-v2.3-rfc/HIVE_V2_3_ACCEPTANCE_TESTS.md`, `tests/test_launch_collateral.py`, `tests/test_maintainer_surfaces.py`, `scripts/smoke_release_install.sh`, `tests/test_release_tooling.py` | Final release/demo validation only |
 
 ## Current Read
 
@@ -58,13 +58,15 @@ What is real now:
 
 What is still holding back a clean release call:
 
-- the actual v2.3 release decision, version/tag cut, and final demo/release verification against the now-closed gates
+- the literal `v2.3.0` tag push and release-automation verification on top of clean `main`
 
 ## Next Blocker
 
-Close the remaining acceptance-driven train against the scope-locked release:
+Cut `v2.3.0` from the now-green, scope-locked release branch:
 
-1. make the final v2.3 release call against the now-closed runtime, sandbox, retrieval, campaign, console, and docs gates
+1. tag and push `v2.3.0` from clean `main`
+2. watch the release workflow through PyPI publish, Homebrew verification, and tap update
+3. run the post-release public install/onboarding verification from a throwaway workspace
 
 ## Update Rule
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mellona-hive"
-version = "2.2.3"
+version = "2.3.0"
 description = "CLI-first orchestration platform for autonomous agents with Git-backed task, run, and memory state"
 readme = { file = "docs/PYPI_README.md", content-type = "text/markdown" }
 requires-python = ">=3.11"

--- a/src/hive/common.py
+++ b/src/hive/common.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any
 
 
-HIVE_VERSION = "2.2.3"
+HIVE_VERSION = "2.3.0"
 
 MARKER_PROJECTS_BEGIN = "<!-- hive:begin projects -->"
 MARKER_PROJECTS_END = "<!-- hive:end projects -->"

--- a/tests/test_console_api.py
+++ b/tests/test_console_api.py
@@ -65,7 +65,7 @@ class TestObserveConsoleApi:
 
         assert health.status_code == 200
         assert health.json()["workspace"] == str(Path(temp_hive_dir).resolve())
-        assert health.json()["version"] == "2.2.3"
+        assert health.json()["version"] == "2.3.0"
         assert status.status_code == 200
         assert status.json()["projects"] == 1
         assert home.status_code == 200

--- a/tests/test_install_story.py
+++ b/tests/test_install_story.py
@@ -182,4 +182,4 @@ def test_release_guide_uses_throwaway_dirs_for_public_install_verification():
     assert "workspace_dir=$(mktemp -d)" in release_doc
     assert "./pip-verify/bin/hive --version" in release_doc
     assert "./pip-verify/bin/hive doctor --json" in release_doc
-    assert 'hive onboard demo --title "Demo project"' in release_doc
+    assert 'hive onboard demo --prompt "Create a small React website about bees."' in release_doc

--- a/tests/test_maintainer_surfaces.py
+++ b/tests/test_maintainer_surfaces.py
@@ -32,7 +32,9 @@ def test_v23_status_doc_tracks_release_gates_and_next_blocker():
     assert "Explainable retrieval, packaged corpus, and traces | Complete" in status_doc
     assert "Release docs, demo, and acceptance alignment | Complete" in status_doc
     assert "built-artifact release smoke path now proves installed-package `hive search`" in status_doc
-    assert "make the final v2.3 release call against the now-closed runtime" in status_doc
+    assert "Status: ready for release" in status_doc
+    assert "tag and push `v2.3.0` from clean `main`" in status_doc
+    assert "release-automation verification on top of clean `main`" in status_doc
 
 
 def test_v23_acceptance_doc_tracks_scope_locked_remote_sandbox_truth():
@@ -58,8 +60,11 @@ def test_release_docs_require_scope_locked_v23_story_and_installed_search_proof(
 
     assert "README, demo walkthrough, compare-harness, and operator docs" in release_doc
     assert "Installed-package `hive search` is proven useful" in release_doc
+    assert "make bump-version BUMP=minor" in release_doc
+    assert "Update [docs/V2_3_STATUS.md](/docs/V2_3_STATUS.md)" in release_doc
     assert 'hive search "runtime contract" --scope api --limit 5 --json' in release_doc
     assert 'hive search "sandbox doctor" --scope examples --limit 5 --json' in release_doc
+    assert 'hive onboard demo --prompt "Create a small React website about bees."' in release_doc
     assert "built-artifact smoke script now proves installed-package" in release_doc
     assert "truthful v2.3 operator surface" in readme
     assert "Hive v2.3 assumes the operator mostly supervises" in operator_doc

--- a/uv.lock
+++ b/uv.lock
@@ -1292,7 +1292,7 @@ wheels = [
 
 [[package]]
 name = "mellona-hive"
-version = "2.2.3"
+version = "2.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "python-dotenv" },


### PR DESCRIPTION
## Summary
- bump the shipped package/runtime version from `2.2.3` to `2.3.0`
- move the v2.3 ledger and release guide from “active train” wording to “ready to tag and publish” wording
- update the small set of release-facing tests that pin the current version or release-doc onboarding example

## What Changed
- updated [project] version metadata and the public runtime version surface
- refreshed the v2.3 status ledger so tag/publish is the only remaining blocker
- updated the release guide to use the prompt-first onboarding verification path and the explicit `make bump-version BUMP=minor` + `uv lock` release cut for this train

## Validation
- `uv run pytest tests/test_install_story.py tests/test_maintainer_surfaces.py tests/test_console_api.py tests/test_release_tooling.py -q`
- `make check`
  - `588 passed, 4 skipped, 1 warning`
- `make release-check`
  - built `mellona_hive-2.3.0.tar.gz` and `mellona_hive-2.3.0-py3-none-any.whl`
  - `twine check` passed
  - uv tool / pip / pipx smoke installs passed

## Review Notes
- this is intentionally the last pre-tag slice: no new product scope, just literal release readiness for `v2.3.0`
